### PR TITLE
Resolve project path to make sure we can get a directory name

### DIFF
--- a/src/back/Project.js
+++ b/src/back/Project.js
@@ -9,7 +9,7 @@ var Project = function (config, filepath, options) {
     this.CLASSNAME = 'project';
     ConfigEmitter.call(this, config);
     this.filepath = filepath;
-    this.id = options.id || path.basename(path.dirname(this.filepath));
+    this.id = options.id || path.basename(path.dirname(fs.realpathSync(this.filepath)));
     this.root = path.dirname(this.filepath);
     this.dataDir = path.join(this.root, 'data');
     try {


### PR DESCRIPTION
As we want to use the name of the directory containing the project file as the name of the project call realpath on the project file to make sure we have a full path so we can get the directory name.
