### PR TITLE
Show checkboxes for individual layers in Data Inspector

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -164,7 +164,9 @@ Config.prototype.toFront = function () {
         autoReload: this.getFromUserConfig('autoReload', true),
         backendPolling: true,
         showCrosshairs: true,
-        dataLayers: {}
+        dataLayers: {
+            '__all__': true
+        }
     };
     this.emit('tofront', {options: options});
     return options;

--- a/src/Config.js
+++ b/src/Config.js
@@ -163,7 +163,8 @@ Config.prototype.toFront = function () {
         exportFormats: Object.keys(this.exporters),
         autoReload: this.getFromUserConfig('autoReload', true),
         backendPolling: true,
-        showCrosshairs: true
+        showCrosshairs: true,
+        dataLayers: {}
     };
     this.emit('tofront', {options: options});
     return options;

--- a/src/back/XRayTile.js
+++ b/src/back/XRayTile.js
@@ -26,7 +26,7 @@ XRayTile.prototype.styleMap = function (project) {
     var self = this,
         map = new mapnik.Map(256, 256),
         idx = 0,
-        chosenLayers = self.options.layer.split(','),
+        chosenLayers = (self.options.layer)? self.options.layer.split(',') : [],
         layers = project.mml.Layer.reduce(function (prev, layer) {
             if (chosenLayers.length && chosenLayers.indexOf(layer.id) === -1) return prev;
             if (idx >= XRayTile.colors.length) idx = 0;

--- a/src/back/XRayTile.js
+++ b/src/back/XRayTile.js
@@ -26,8 +26,9 @@ XRayTile.prototype.styleMap = function (project) {
     var self = this,
         map = new mapnik.Map(256, 256),
         idx = 0,
+        chosenLayers = self.options.layer.split(','),
         layers = project.mml.Layer.reduce(function (prev, layer) {
-            if (self.options.layer && self.options.layer !== '__all__' && self.options.layer !== layer.id) return prev;
+            if (chosenLayers.length && chosenLayers.indexOf(layer.id) === -1) return prev;
             if (idx >= XRayTile.colors.length) idx = 0;
             return prev + Utils.template(XRayTile.layer_template, {id: layer.id, rgb: XRayTile.colors[idx++]});
         }, ''),

--- a/src/front/DataInspector.js
+++ b/src/front/DataInspector.js
@@ -2,14 +2,12 @@ L.TileLayer.XRay = L.TileLayer.extend({
 
     getTileUrl: function (tilePoint) {
         this.options.version = Date.now();
-        var keys = Object.keys(L.K.Config);
-        if (L.K.Config['dataInspectorLayer___all__'] === true) {
-            this.options.showLayer = '';
-        } else {
+        if (L.K.Config['dataInspector']) {
+            var keys = Object.keys(L.K.Config['dataInspector']);
             var showLayers = [];
             for(var k = 0; k < keys.length; k++) {
-                if (keys[k].indexOf("dataInspectorLayer_") === 0 && L.K.Config[keys[k]] === true) {
-                    showLayers.push(keys[k].split("dataInspectorLayer_")[1]);
+                if (L.K.Config[keys[k]] === true) {
+                    showLayers.push(keys[k]);
                 }
             }
             this.options.showLayer = showLayers.join(",");
@@ -42,7 +40,7 @@ L.Kosmtik.DataInspector = L.Class.extend({
                 z: this.map.getZoom(),
                 lat: e.latlng.lat,
                 lng: e.latlng.lng,
-                layer: L.K.Config.dataInspectorLayer || ''
+                layer: ''
             });
             L.K.Xhr.get(url, {
                 callback: function (status, data) {
@@ -67,13 +65,12 @@ L.Kosmtik.DataInspector = L.Class.extend({
         this.title = L.DomUtil.create('h3', '', this.container);
         this.formContainer = L.DomUtil.create('div', '', this.container);
         this.title.innerHTML = 'Data Inspector';
-        var layers = [['__all__', 'all']].concat(L.K.Config.project.layers.map(function (l) {return [l.name, l.name];}));
+        var layers = L.K.Config.project.layers.map(function (l) {return l.name;});
         var backgrounds = [['black', 'black'], ['transparent', 'transparent']];
-        var checkLayers = [];
+        var checkLayers = [['dataInspector.__all__', {handler: L.FormBuilder.LabeledCheckBox, text: 'Show All', checked: true} ]];
         for (var i = 0; i < layers.length; i++) {
-          var checkboxID = 'dataInspectorLayer_' + layers[i][0];
-          var checkThis = L.K.Config[checkboxID] || (i === 0);
-          var checkbox = [checkboxID, {handler: L.FormBuilder.LabeledCheckBox, text: 'Show ' + layers[i][1], checked: checkThis }];
+          var checkboxID = 'dataInspector.' + layers[i];
+          var checkbox = [checkboxID, {handler: L.FormBuilder.LabeledCheckBox, text: 'Show ' + layers[i] }];
           checkLayers.push(checkbox);
         }
         this.sidebarForm = new L.K.FormBuilder(L.K.Config, [

--- a/src/front/DataInspector.js
+++ b/src/front/DataInspector.js
@@ -2,16 +2,21 @@ L.TileLayer.XRay = L.TileLayer.extend({
 
     getTileUrl: function (tilePoint) {
         this.options.version = Date.now();
-        if (L.K.Config['dataInspector']) {
-            var keys = Object.keys(L.K.Config['dataInspector']);
-            var showLayers = [];
-            for(var k = 0; k < keys.length; k++) {
-                if (L.K.Config[keys[k]] === true) {
-                    showLayers.push(keys[k]);
+        var showLayers = [];
+        var keys = Object.keys(L.K.Config.dataLayers);
+        for(var k = 0; k < keys.length; k++) {
+            if (L.K.Config.dataLayers['__all__'] === true) {
+                // display all layers, uncheck all except top Show All box
+                if (keys[k] !== '__all__') {
+                    document.getElementsByName(keys[k])[0].checked = false;
                 }
             }
-            this.options.showLayer = showLayers.join(",");
+            else if (L.K.Config.dataLayers[keys[k]] === true) {
+                // display only the checked layers
+                showLayers.push(keys[k]);
+            }
         }
+        this.options.showLayer = showLayers.join(",");
         this.options.background = L.K.Config.dataInspectorBackground || '';
         return L.TileLayer.prototype.getTileUrl.call(this, tilePoint);
     }
@@ -67,11 +72,11 @@ L.Kosmtik.DataInspector = L.Class.extend({
         this.title.innerHTML = 'Data Inspector';
         var layers = L.K.Config.project.layers.map(function (l) {return l.name;});
         var backgrounds = [['black', 'black'], ['transparent', 'transparent']];
-        var checkLayers = [['dataInspector.__all__', {handler: L.FormBuilder.LabeledCheckBox, text: 'Show All', checked: true} ]];
+        var checkLayers = [['dataLayers.__all__', {handler: L.FormBuilder.LabeledCheckBox, text: 'Show All', checked: true} ]];
         for (var i = 0; i < layers.length; i++) {
-          var checkboxID = 'dataInspector.' + layers[i];
-          var checkbox = [checkboxID, {handler: L.FormBuilder.LabeledCheckBox, text: 'Show ' + layers[i] }];
-          checkLayers.push(checkbox);
+            var checkboxID = 'dataLayers.' + layers[i];
+            var checkbox = [checkboxID, {handler: L.FormBuilder.LabeledCheckBox, text: 'Show ' + layers[i] }];
+            checkLayers.push(checkbox);
         }
         this.sidebarForm = new L.K.FormBuilder(L.K.Config, [
             ['dataInspector', {handler: L.K.Switch, label: 'Active'}],

--- a/src/front/DataInspector.js
+++ b/src/front/DataInspector.js
@@ -4,15 +4,15 @@ L.TileLayer.XRay = L.TileLayer.extend({
         this.options.version = Date.now();
         var keys = Object.keys(L.K.Config);
         if (L.K.Config['dataInspectorLayer___all__'] === true) {
-          this.options.showLayer = '';
+            this.options.showLayer = '';
         } else {
-          var showLayers = [];
-          for(var k = 0; k < keys.length; k++) {
-            if (keys[k].indexOf("dataInspectorLayer_") === 0 && L.K.Config[keys[k]] === true) {
-              showLayers.push(keys[k].split("dataInspectorLayer_")[1]);
+            var showLayers = [];
+            for(var k = 0; k < keys.length; k++) {
+                if (keys[k].indexOf("dataInspectorLayer_") === 0 && L.K.Config[keys[k]] === true) {
+                    showLayers.push(keys[k].split("dataInspectorLayer_")[1]);
+                }
             }
-          }
-          this.options.showLayer = showLayers.join(",");
+            this.options.showLayer = showLayers.join(",");
         }
         this.options.background = L.K.Config.dataInspectorBackground || '';
         return L.TileLayer.prototype.getTileUrl.call(this, tilePoint);
@@ -143,22 +143,22 @@ L.Kosmtik.DataInspector = L.Class.extend({
 });
 
 L.FormBuilder.LabeledCheckBox = L.FormBuilder.CheckBox.extend({
-  build: function () {
-    var container = L.DomUtil.create('div', 'formbox', this.form);
-    var label = L.DomUtil.create('label', 'layer-label', container);
-    this.input = L.DomUtil.create('input', this.options.className || '', label);
-    this.input.type = 'checkbox';
-    this.input.name = this.name;
-    this.input._helper = this;
-    this.fetch();
-    L.DomEvent.on(this.input, 'change', this.sync, this);
-    if (typeof this.options.checked !== 'undefined') {
-      this.input.checked = this.options.checked;
+    build: function () {
+        var container = L.DomUtil.create('div', 'formbox', this.form);
+        var label = L.DomUtil.create('label', 'layer-label', container);
+        this.input = L.DomUtil.create('input', this.options.className || '', label);
+        this.input.type = 'checkbox';
+        this.input.name = this.name;
+        this.input._helper = this;
+        this.fetch();
+        L.DomEvent.on(this.input, 'change', this.sync, this);
+        if (typeof this.options.checked !== 'undefined') {
+            this.input.checked = this.options.checked;
+        }
+        if (this.options.text) {
+            var layerLabel = L.DomUtil.create('span', 'layer-name', label);
+            var textNodeProperty = ('innerText' in layerLabel)? 'innerText' : 'textContent';
+            layerLabel[textNodeProperty] = this.options.text;
+        }
     }
-    if (this.options.text) {
-      var layerLabel = L.DomUtil.create('span', 'layer-name', label);
-      var textNodeProperty = ('innerText' in layerLabel)? 'innerText' : 'textContent';
-      layerLabel[textNodeProperty] = this.options.text;
-    }
-  }
 });

--- a/src/front/Sidebar.css
+++ b/src/front/Sidebar.css
@@ -69,9 +69,15 @@
   margin-bottom: 28px;
 }
 .sidebar-map .leaflet-right {
-  transition: right 500ms; 
-  right: 470px; 
+  transition: right 500ms;
+  right: 470px;
 }
 .sidebar.collapsed ~ .sidebar-map .leaflet-right {
   right: 70px;
+}
+.layer-label {
+  padding-top: 4px;
+}
+.layer-name {
+  margin-left: 10px;
 }


### PR DESCRIPTION
Produces a scrollable list of all available layers with checkboxes, looks like this:

![screen shot 2015-01-11 at 5 00 56 pm](https://cloud.githubusercontent.com/assets/643918/5697047/6cfd2f24-99b3-11e4-8a97-0a1056a1a34a.png)
