### PR TITLE
Fix config not defined for node v0.10.35

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -39,14 +39,15 @@ Config.prototype.getUserConfigPath = function () {
 };
 
 Config.prototype.loadUserConfig = function () {
-    var configpath = this.getUserConfigPath();
+    var configpath = this.getUserConfigPath(),
+        config = {};
     try {
         config = yaml.safeLoad(fs.readFileSync(configpath, 'utf-8'));
         this.log('Loading config from', configpath);
     } catch (err) {
         this.log('No usable config file found in', configpath);
     }
-    this.userConfig = config || {};
+    this.userConfig = config;
 };
 
 Config.prototype.saveUserConfig = function () {


### PR DESCRIPTION
Even though x = x || y usually should set x = y for all undefined x, I at least get a ReferenceError for config being undefined on line #49, after commit 1f785b46605d98d9ba6f4d4d47ece7fff8602ca6. 

I'm not sure exactly why, so I'd assume it's due to either an oddity with the v8 engine, though it seems... odd.

```
/usr/local/kosmtik/src/Config.js:49
    this.userConfig = config ||��{};
                      ^
ReferenceError: config is not defined
    at Config.loadUserConfig (/usr/local/kosmtik/src/Config.js:49:23)
    at new Config (/usr/local/kosmtik/src/Config.js:23:10)
    at Object.<anonymous> (/usr/local/kosmtik/index.js:11:14)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:929:3
```

Anyhow, simply defining it ahead of time as was done before 1f785b46605d98d9ba6f4d4d47ece7fff8602ca6 solves it, even though it doesn't look as elegant.