### PR TITLE
Fix for TypeError on tolerance parameter in query method

### DIFF
--- a/src/back/ProjectServer.js
+++ b/src/back/ProjectServer.js
@@ -163,7 +163,7 @@ ProjectServer.prototype.queryTile = function (z, lat, lon, res, query) {
         var tile = new tileClass(z, x, y, {metatile: 1});
         return tile.renderToVector(self.project, map, function (err, t) {
             if (err) return self.raise(err.message, res, release);
-            var options = {tolerance: parseInt(query.tolerance) || 100};
+            var options = {tolerance: parseInt(query.tolerance, 10) || 100};
             var results = [], layers = [];
             var doQuery = function (results, options) {
                 var features = t.query(lon, lat, options);

--- a/src/back/ProjectServer.js
+++ b/src/back/ProjectServer.js
@@ -163,7 +163,7 @@ ProjectServer.prototype.queryTile = function (z, lat, lon, res, query) {
         var tile = new tileClass(z, x, y, {metatile: 1});
         return tile.renderToVector(self.project, map, function (err, t) {
             if (err) return self.raise(err.message, res, release);
-            var options = {tolerance: query.tolerance || 100};
+            var options = {tolerance: parseInt(query.tolerance) || 100};
             var results = [], layers = [];
             var doQuery = function (results, options) {
                 var features = t.query(lon, lat, options);


### PR DESCRIPTION
If tolerance is included in the /query querystring params then this patch fixes the error when it encounters it as a string and not the expected integer. 
Example call to /query http://localhost:6789/osm-bright/query/9/52.44429203405363/-1.8731689453124998/?tolerance=300&layer=

The error looked like this:

```
/home/tim/projects/kosmtik/src/back/ProjectServer.js:169
                var features = t.query(lon, lat, options);
                                 ^
TypeError: tolerance value must be a number
    at doQuery (/home/tim/projects/kosmtik/src/back/ProjectServer.js:169:34)
    at /home/tim/projects/kosmtik/src/back/ProjectServer.js:180:17
```