### PR TITLE
Fix for bug where xray tile with no data caused crash refs #94

### DIFF
--- a/src/back/XRayTile.js
+++ b/src/back/XRayTile.js
@@ -15,8 +15,10 @@ var XRayTile = function (z, x, y, data, options) {
 XRayTile.prototype.render = function (project, map, cb) {
     var styleMap = this.styleMap(project),
         vtile = new mapnik.VectorTile(this.z, this.x, this.y);
-    if (this.data.length) vtile.setData(this.data);
-    vtile.parse();
+    if (this.data.length){
+        vtile.setData(this.data);
+        vtile.parse();
+    }
     vtile.render(styleMap, new mapnik.Image(256, 256), cb);
 };
 


### PR DESCRIPTION
This Pull Request fixes an issue where if an xray tile has no data it will crash kosmtik. It is for issue #94 