### PR TITLE
Set map buffer size, and use when rendering vector tiles

### DIFF
--- a/src/back/Project.js
+++ b/src/back/Project.js
@@ -62,8 +62,8 @@ Project.prototype.createMapPool = function (options) {
     options = options || {};
     this.render();
     this.config.log('Loading map…');
-    // TODO bufferSize?
-    this.mapPool = this.mapnikPool.fromString(this.xml, {size: options.size || this.tileSize()}, {base: this.root});
+    if(!options.size) options.size = this.tileSize();
+    this.mapPool = this.mapnikPool.fromString(this.xml, options, {base: this.root});
     this.config.log('Map ready');
     return this.mapPool;
 };

--- a/src/back/ProjectServer.js
+++ b/src/back/ProjectServer.js
@@ -286,8 +286,8 @@ ProjectServer.prototype.reload = function (res) {
 };
 
 ProjectServer.prototype.initMapPools = function () {
-    this.mapPool = this.project.createMapPool();
-    this.vectorMapPool = this.project.createMapPool({size: 256});
+    this.mapPool = this.project.createMapPool({bufferSize:256});
+    this.vectorMapPool = this.project.createMapPool({size: 256, bufferSize:256});
 };
 
 exports.ProjectServer = ProjectServer;

--- a/src/back/VectorBasedTile.js
+++ b/src/back/VectorBasedTile.js
@@ -60,7 +60,7 @@ VectorBasedTile.prototype.render = function (project, map, cb) {
     var self = this;
     this._render(project, map, function (err, vtile) {
         if (err) cb(err);
-        else vtile.render(map, new mapnik.Image(self.width, self.height), cb);
+        else vtile.render(map, new mapnik.Image(self.width, self.height), {'buffer_size': map.bufferSize}, cb);
     });
 };
 


### PR DESCRIPTION
Without this change, having buffers in vector tiles had no effect, because data outside the tile bounds was not used in rendering. This caused lots of cutoff labels. 