### PR TITLE
Add .travis.yml to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
-before_install:
-    - sudo add-apt-repository -y ppa:mapnik/nightly-trunk
-    - sudo apt-get update -qq
-    - sudo apt-get -y install libmapnik=3.0.0* mapnik-utils=3.0.0* libmapnik-dev=3.0.0* mapnik-input-plugin-postgis=3.0.0* mapnik-input-plugin-sqlite=3.0.0* mapnik-input-plugin-gdal=3.0.0* mapnik-input-plugin-ogr=3.0.0*
 install:
     - npm install
     - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 node_js:
-  - "4.1"
+  - "5.5"
+  - "4.2"
+  - "0.12"
+  - "0.10"
+git:
+  depth: 10
 env:
   - CXX=g++-4.8
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+node_js:
+  - "4.1"
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+before_install:
+    - sudo add-apt-repository -y ppa:mapnik/nightly-trunk
+    - sudo apt-get update -qq
+    - sudo apt-get -y install libmapnik=3.0.0* mapnik-utils=3.0.0* libmapnik-dev=3.0.0* mapnik-input-plugin-postgis=3.0.0* mapnik-input-plugin-sqlite=3.0.0* mapnik-input-plugin-gdal=3.0.0* mapnik-input-plugin-ogr=3.0.0*
+install:
+    - npm install
+    - npm test


### PR DESCRIPTION
I added the `.travis.yml` file. It can run the tests.
The other purpose of this PR in the long run is also to add plugins installation tests as they fails depending of environment.

I should mention I already tested the configuration at https://travis-ci.org/ThomasG77/kosmtik where it fails due to some kosmtik tests not working ;)
