### PR TITLE
read showCrosshairs and backendPolling from UserConfig

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -171,8 +171,8 @@ Config.prototype.toFront = function () {
     var options = {
         exportFormats: Object.keys(this.exporters),
         autoReload: this.getFromUserConfig('autoReload', true),
-        backendPolling: true,
-        showCrosshairs: true,
+        backendPolling: this.getFromUserConfig('backendPolling', true),
+        showCrosshairs: this.getFromUserConfig('showCrosshairs', true),
         dataInspectorLayers: {
             '__all__': true
         }


### PR DESCRIPTION
Because i never want to see the crosshairs. Added backendPolling to UserConfig because it seems like all the options should be settable in there.