### PR TITLE
upgrade carto to 0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Yohan Boniface",
   "license": "WTFPL",
   "dependencies": {
-    "carto": "^0.15.2",
+    "carto": "^0.16.0",
     "generic-pool": "^2.2.0",
     "js-yaml": "^3.4.2",
     "json-localizer": "0.0.3",


### PR DESCRIPTION
carto@0.16.0 is out officially.