### PR TITLE
Add support for overzoom rendering of vector tiles

### DIFF
--- a/src/back/VectorBasedTile.js
+++ b/src/back/VectorBasedTile.js
@@ -31,9 +31,6 @@ VectorBasedTile.prototype._render = function (project, map, cb) {
             y: Math.floor(params.y/2)
         };
     }
-    if(params.z != this.z) {
-        console.log("overzooming");
-    }
 
     var vtile = new mapnik.VectorTile(params.z, params.x, params.y),
         processed = 0,

--- a/src/back/VectorBasedTile.js
+++ b/src/back/VectorBasedTile.js
@@ -15,16 +15,12 @@ VectorBasedTile.prototype._render = function (project, map, cb) {
     map.zoomToBox(this.projection.forward([this.minX, this.minY, this.maxX, this.maxY]));
 
     //Support for overzooming
-    var maxzoom = 99,
-        params = {
+    var params = {
             z: this.z,
             x: this.x,
             y: this.y
         };
-    for (var i = 0; i < project.mml.source.length; i++) {
-        maxzoom = Math.min(maxzoom, project.mml.source[i].maxzoom);
-    }
-    while(params.z > maxzoom) {
+    while(params.z > project.mml.sourceMaxzoom) {
         params = {
             z: params.z - 1,
             x: Math.floor(params.x/2),

--- a/src/plugins/datasource-loader/index.js
+++ b/src/plugins/datasource-loader/index.js
@@ -64,6 +64,7 @@ DataSourceLoader.prototype.attachSourceUrl = function (source, project) {
 
 DataSourceLoader.prototype.processTileJSON = function (source, tilejson) {
     source.url = tilejson.tiles[0];
+    source.maxzoom = tilejson.maxzoom;
 };
 
 exports.Plugin = DataSourceLoader;

--- a/src/plugins/datasource-loader/index.js
+++ b/src/plugins/datasource-loader/index.js
@@ -57,7 +57,9 @@ DataSourceLoader.prototype.loadLocalSource = function (source, config) {
         ext = path.extname(filepath);
     if (ext !== '.yml') filepath = path.join(filepath, 'data.yml');
     var project = new Project(config, filepath);
+    project.load(false);
     this.attachSourceUrl(source, project);
+    source.maxzoom = project.mml.maxzoom;
     config.server.registerProject(project);
 };
 

--- a/src/plugins/datasource-loader/index.js
+++ b/src/plugins/datasource-loader/index.js
@@ -14,8 +14,17 @@ var DataSourceLoader = function (config) {
 DataSourceLoader.prototype.patchMML = function (e) {
     if (!e.project.mml) return e.continue();
     var processed = 0, self = this,
+        sourceMaxzoom = 100,
         sources = e.project.mml.source,
-        commit = function () {if (++processed === sources.length) e.continue();},
+        commit = function () {
+            if (++processed === sources.length){
+                for (var i = 0; i < sources.length; i++) {
+                    sourceMaxzoom = Math.min(sourceMaxzoom, sources[i].maxzoom);
+                }
+                e.project.mml.sourceMaxzoom = sourceMaxzoom;
+                e.continue();
+            }
+        },
         processTileJSON = function (source, json) {
             self.processTileJSON(source, json);
             commit();


### PR DESCRIPTION
This adds support for rendering when the max zoom for a style is greater than the max zoom for the vector tile source. Currently this is only supported for tilejson based sources.