### PR TITLE
use x1, x2 x3… instead of 1,2,3 in the ExportScaleChooser

### DIFF
--- a/src/plugins/base-exporters/front/export.js
+++ b/src/plugins/base-exporters/front/export.js
@@ -11,7 +11,7 @@ L.Kosmtik.ExportFormatChooser = L.FormBuilder.Select.extend({
 L.Kosmtik.ExportScaleChooser = L.FormBuilder.IntSelect.extend({
 
     getOptions: function () {
-        return [1, 2, 3, 4, 5].map(function (item) {return [item, item];});
+        return [1, 2, 3, 4, 5].map(function (item) {return [item, '&times; ' + item];});
     }
 
 });


### PR DESCRIPTION
rationale : 1, 2, 3, 4, 5 could be confused with zoom levels