### PR TITLE
[WIP] Add a home page

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -51,13 +51,14 @@ Config.prototype.loadUserConfig = function () {
     } catch (err) {
         this.log('No usable config file found in', configpath);
     }
-    this.userConfig = config;
+    this.userConfig = config || {};
 };
 
 Config.prototype.saveUserConfig = function () {
     var configpath = this.getUserConfigPath(),
         self = this;
     fs.writeFile(configpath, yaml.safeDump(this.userConfig), function (err) {
+        if (err) throw err;
         self.log('Saved env conf to', configpath);
     });
 };
@@ -171,7 +172,8 @@ Config.prototype.initStatics = function () {
         '/src/front/FormBuilder.js',
         '/src/front/Settings.js',
         '/src/front/Command.js',
-        '/src/front/Map.js'
+        '/src/front/Map.js',
+        '/src/front/ProjectLoader.js',
     ];
     this._css = [
         '/node_modules/leaflet/dist/leaflet.css',
@@ -197,7 +199,8 @@ Config.prototype.toFront = function () {
         showCrosshairs: this.getFromUserConfig('showCrosshairs', true),
         dataInspectorLayers: {
             '__all__': true
-        }
+        },
+        projects: this.getFromUserConfig('projects', {})
     };
     this.emit('tofront', {options: options});
     return options;

--- a/src/front/Core.css
+++ b/src/front/Core.css
@@ -516,6 +516,7 @@ input.switch:checked ~ label:after {
 .help-panel .shortcuts td {
     text-align: right;
 }
+
 /* *********************** */
 /*      Export panel       */
 /* *********************** */
@@ -591,6 +592,53 @@ ul.k-autocomplete-results {
 }
 .leaflet-popup-content .data-inspector table + table {
     border-top: 1px solid #666;
+}
+
+/* *********************** */
+/*           Home          */
+/* *********************** */
+#content {
+    padding: 60px 20px;
+}
+#content h3 {
+    margin-bottom: 20px;
+}
+.card {
+    float: none;
+    clear: both;
+    max-width: 400px;
+    background-color: #fefefe;
+    padding: 20px;
+    border: 1px solid #eee;
+    border-radius: 2px;
+    background-repeat: no-repeat;
+    background-position: center right 5px;
+    cursor: pointer;
+    text-align: center;
+}
+.card h4 {
+    text-transform: uppercase;
+}
+.card img {
+    height: 200px;
+}
+.card + .card {
+    margin-top: 20px;
+}
+.grid {
+    display: flex;
+    display: -webkit-flex;
+    -webkit-flex-wrap: wrap;
+    flex-wrap: wrap;
+}
+.grid .card {
+    clear: none;
+    margin-right: 10px;
+    margin-top: 0;
+    margin-bottom: 10px;
+    flex-grow: 1;
+    flex-basis: 300px;
+    position: relative;
 }
 
 

--- a/src/front/Core.js
+++ b/src/front/Core.js
@@ -1,4 +1,5 @@
-L.Kosmtik = L.K = {};
+L.KosmtikSingleton = L.Evented.extend({});
+L.Kosmtik = L.K = new L.KosmtikSingleton();
 
 
 /*************/

--- a/src/front/ProjectLoader.js
+++ b/src/front/ProjectLoader.js
@@ -1,0 +1,49 @@
+L.K.Home = L.Evented.extend({
+
+    rows: [],
+
+    addRow: function (builder, context) {
+        this.rows.push([builder, context || this]);
+    },
+
+    build: function () {
+        var parent = L.DomUtil.get('content');
+        for (var i = 0; i < this.rows.length; i++) {
+            this.buildOne(this.rows[i]);
+        }
+        this.fire('build');
+    },
+
+    buildOne: function (row, parent) {
+        var container = L.DomUtil.create('div', 'row', parent);        
+        row[0].call(row[1], container);
+    }
+
+});
+
+L.K.home = new L.K.Home();
+
+L.K.ProjectLoader = L.Class.extend({
+
+    build: function () {
+        var container = L.DomUtil.get('content');
+        var title = L.DomUtil.create('h3', '', container);
+        title.innerHTML = 'Projects';
+        var list = L.DomUtil.create('ul', 'project-list grid', container);
+        for (id in L.K.Config.projects) this.addProject(L.K.Config.projects[id], list);
+    },
+
+    addProject: function (project, container) {
+        var li = L.DomUtil.create('li', 'card', container);
+        var title = L.DomUtil.create('h4', '', li);
+        title.textContent = project.name || project.id;
+        var img = L.DomUtil.create('img', '', li);
+        img.src = '/' + project.id + '/.thumb.png';
+        L.DomEvent.on(li, 'click', function () {
+            window.location = '/' + project.id;
+        });
+    }
+
+});
+var loader = new L.K.ProjectLoader();
+L.K.home.addRow(loader.build, loader);

--- a/src/front/index.html
+++ b/src/front/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <title>Kosmtik</title>
+  %%JS%%
+  %%CSS%%
+</head>
+<body>
+    <div class="toolbar"><a href="/" class="brand">kosmtik</a></div>
+    <div id="content"></div>
+    <script type="text/javascript">
+        L.K.home.build();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Work in progress, but should be reviewable if someone wants to step in.

The main idea is to have a home page on kosmtik, that would in a first step display all the known projects, but can host any other information we could find useful, and any plugin can plug into the home to add its info. For example, we were talking during the week-end about a kosmtik-example plugin that would list in the home page all the kown CartoCSS project that kosmtik can read (maybe starting by the one that does not need installation/configuration, but not only).

What this PR adds:
- [x] when we start kosmtik serving a project, this project is added to the local settings, so Kosmtik knows about it
- [x] the "/" URL no more redirects to the "default project" (i.e. the one given as parameter)
- [x] it's now possible to run `node index.js serve` without specifying a project (but only known projects will be visible on the home page, and thus accessible)
- [x] all the known projects are displayed on the home page
- [x] when a project is loaded, we generate a thumb, so we can display it on the home page

Nice things to add before merging:
- [ ] allow to run "node index.js", so `serve` becomes the default action
- [ ] allow to load a new project from the home page; issue here is that, for security reasons, using the OS filebrowser only give us access to the pointed file (it's content and name), but not it's local path, which is what kosmtik needs; solution is certainly to have our own simple filebrowser (like Tilemill had, iirc); switching to an electron based project is maybe another option, but more ambitious
