### PR TITLE
fix documentation - give the real name of parameter

### DIFF
--- a/src/plugins/base-exporters/index.js
+++ b/src/plugins/base-exporters/index.js
@@ -21,7 +21,7 @@ var BaseExporters = function (config) {
         metavar: 'INT',
         default: 1000
     });
-    config.commands.export.option('bbox', {
+    config.commands.export.option('bounds', {
         help: 'BBox to use [Default: project extent]',
         metavar: 'minX,minY,maxX,maxY'
     });


### PR DESCRIPTION
bug found by @nebulon42 - https://github.com/kosmtik/kosmtik/issues/150#issuecomment-228179851

after change

```
mateusz@ugluk:~/Desktop/tmp/kosmtik$ node index.js export -help
[Core] Loading config from /home/mateusz/.config/kosmtik.yml
[Core] Loading plugin from ../plugins/base-exporters/index.js
[Core] Loading plugin from ../plugins/hash/index.js
[Core] Loading plugin from ../plugins/local-config/index.js
[Core] Loading plugin from ../plugins/datasource-loader/index.js
[Core] Unable to load plugin kosmtik-map-compare MODULE_NOT_FOUND
[Core] → try: node index.js plugins --install kosmtik-map-compare
[Core] Unable to load plugin kosmtik-magnacarto MODULE_NOT_FOUND
[Core] → try: node index.js plugins --install kosmtik-magnacarto
'-p' expects a value


Usage: node index.js export [project] [options]

project     Project to export.

Options:
   --mapnik-version               Optional mapnik reference version to be passed to Carto  [3.0.0]
   --proxy                        Optional proxy to use when doing http requests
   --keep-cache                   Do not flush cached metatiles on project load
   --renderer                     Specify a renderer by its name, carto is the default.  [carto]
   --localconfig                  Path to local config file [Default: {projectpath}/localconfig.json|.js]
   --output PATH                  Filepath to save in
   --width INT                    Width of the export  [1000]
   --height INT                   Height of the export  [1000]
   --bounds minX,minY,maxX,maxY   BBox to use [Default: project extent]
   --scale INT                    Scale the exported image  [1]
   --format FORMAT                Format of the export  [xml]

Export a project
```