### PR TITLE
Use an exact Mapnik version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "leaflet": "^1.0.0-rc.3",
     "leaflet-formbuilder": "^0.2.0",
     "leaflet-hash": "^0.2.1",
-    "mapnik": "^3.5.13",
+    "mapnik": "3.5.13",
     "nomnom": "^1.8.1",
     "npm": "^3.10.6",
     "request": "^2.64.0",


### PR DESCRIPTION
Mapnik doesn't follow SemVer, and frequently something breaks in a new version.