### PR TITLE
Set user agent to kosmtik + version

### DIFF
--- a/src/back/Helpers.js
+++ b/src/back/Helpers.js
@@ -1,4 +1,7 @@
-var request = require('request');
+var request = require('request'),
+    kosmtikPackage = require('../../package'),
+    version = kosmtikPackage.version;
+
 
 var Helpers = function (config) {
     this.config = config;
@@ -6,6 +9,8 @@ var Helpers = function (config) {
 
 Helpers.prototype.request = function (options, callback) {
     if(this.config.parsed_opts.proxy) options.proxy = this.config.parsed_opts.proxy;
+    if(!options.headers) options.headers = {};
+    options.headers["User-Agent"] = "kosmtik " + version;
     return request(options, callback);
 };
 

--- a/src/back/Helpers.js
+++ b/src/back/Helpers.js
@@ -1,6 +1,5 @@
 var request = require('request'),
-    kosmtikPackage = require('../../package'),
-    version = kosmtikPackage.version;
+    version = require('../../package').version;
 
 
 var Helpers = function (config) {


### PR DESCRIPTION
By default kosmtik was not sending a user-agent header, In debugging a tile server issue it was really helpful to be able to identify the kosmtik requests by greping.