### PR TITLE
pass uri through for unknown source protocols

### DIFF
--- a/src/back/loader/Base.js
+++ b/src/back/loader/Base.js
@@ -50,6 +50,8 @@ BaseLoader.prototype.normalizeSource = function (source) {
             source.tilejson = uri.href;
         } else if (source.protocol.indexOf('tms') === 0) {
             source.url = uri.href.replace(/^tms/, 'http');
+        } else {
+            source.url = uri.href;
         }
     }
     return source;


### PR DESCRIPTION
This is needed to enable plugins that add support for additional source protocols