### PR TITLE
do not set Mapnik patch version to 0

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -225,7 +225,6 @@ Config.prototype.log = function () {
 
 Config.prototype.defaultMapnikVersion = function () {
     var version = semver(mapnik.versions.mapnik);
-    version.patch = 0;
     return version.format();
 };
 


### PR DESCRIPTION
So that newest Mapnik version is selected for Carto.