### PR TITLE
streamline CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ OpenStreetMap data (and more).
 For now, only Carto based projects are supported (with .mml or .yml config),
 but in the future we hope to plug in MapCSS too.
 
-**Alpha version, installable only from source**
-
 
 ## Lite
 
@@ -29,57 +27,46 @@ Only the core needs:
 ![screenshot](https://raw.github.com/kosmtik/kosmtik/master/screenshot.png "Screenshot of Kosmtik")
 
 
-## Install
+## Install or Update
 
-Clone this repository with ``git clone https://github.com/kosmtik/kosmtik.git``,
-go to the downloaded directory with ``cd kosmtik``, and run:
+    npm -g install kosmtik
 
-```
-npm install
-```
+This might need root/Administrator rights. If you cannot install globally
+you can also install locally with
 
-## Update
+    npm install kosmtik
 
-Obtain changes from repository (e.g. `git pull`)
-
-    rm -rf node_modules && npm install
+This will create a `node_modules/kosmtik` folder. You then have to replace all occurences of `kosmtik`
+below with `node node_modules/kosmtik/index.js`.
 
 To reinstall all plugins:
 
-    node index.js plugins --reinstall
+    kosmtik plugins --reinstall
 
 ## Usage
 
 To get command line help, run:
 
-```
-node index.js -h
-```
+    kosmtik -h
 
 To run a Carto project (or `.yml`, `.yaml`):
 
-```
-node index.js serve <path/to/your/project.mml>
-```
+    kosmtik serve <path/to/your/project.mml>
 
 Then open your browser at http://127.0.0.1:6789/.
 
 
 You may also want to install plugins. To see the list of available ones, type:
 
-```
-node index.js plugins --available
-```
+    kosmtik plugins --available
 
 And then pick one and install it like this:
-```
-node index.js plugins --install pluginname
-```
+
+    kosmtik plugins --install pluginname
 
 For example:
-```
-node index.js plugins --install kosmtik-map-compare [--install kosmtik-overlay…]
-```
+
+    kosmtik plugins --install kosmtik-map-compare [--install kosmtik-overlay…]
 
 
 ## Local config
@@ -168,4 +155,4 @@ renderer name (e.g. `carto` for the default renderer or `magnacarto` for the Mag
 - [kosmtik-mbtiles-export](https://github.com/kosmtik/kosmtik-mbtiles-export): export your project in MBTiles
 - [kosmtik-magnacarto](https://github.com/kosmtik/kosmtik-magnacarto): Magnacarto renderer for CartoCSS
 
-Run `node index.js plugins --available` to get an up to date list.
+Run `kosmtik plugins --available` to get an up to date list.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.0.13",
   "description": "Make maps with OpenStreetMap and Mapnik",
   "main": "index.js",
+  "bin": "./index.js",
+  "preferGlobal": true,
   "scripts": {
     "test": "node node_modules/.bin/mocha"
   },


### PR DESCRIPTION
Currently the process of installing, updating and using Kosmtik is a bit problematic for non-developers. This could be streamlined by using the power of NPM. As prerequisite we would need to move to regular releases and regular updates at the NPM registry. At the same time I would propose to drop the alpha version warning.

NPM allows to specify a `bin` property. When the package is installed globally the "binary" is linked into the path thus enabling `kosmtik serve ...` and the like instead of `node index.js serve ...`. Updating is also much easier. All you need to do is to call `npm install -g kosmtik` again.

The `preferGlobal` should print a warning that Kosmtik is best installed globally but it is still possible to install it locally.

**needs testing**
I have no idea how well that works on Windows, maybe someone can try it out. We could also start a test by pushing a new version to the NPM registry with the `bin`property and leave the documentation unchanged for now. I have tested with `npm link` but proper testing would need a update at the registry.

@yohanboniface  Currently you are the only one that can `npm publish`. Do you want to keep it that way or extend rights to other collaborators?