### PR TITLE
[WIP] Make vector tile caching disablable

### DIFF
--- a/src/back/Project.js
+++ b/src/back/Project.js
@@ -135,11 +135,15 @@ Project.prototype.initMetaCache = function (e) {
 
 Project.prototype.initVectorCache = function (e) {
     var self = this, dir = this.getVectorCacheDir();
-    Utils.mkdirs(dir, function (err) {
-        if (err) throw err;
-        self.config.log('Created vector cache dir', dir);
+    if (dir) {
+        Utils.mkdirs(dir, function (err) {
+            if (err) throw err;
+            self.config.log('Created vector cache dir', dir);
+            e.continue();
+        });
+    } else {
         e.continue();
-    });
+    }
 };
 
 exports.Project = Project;


### PR DESCRIPTION
The recently added vector tile caching is problematic for some uses, like when the vector tiles are under development, not the style.

This disables the caching if `project.getVectorCacheDir` returns null, but I haven't yet added a way to make it return null, other than replacing the function in a localconfig.js file, which is what im doing now.
```js
project.getVectorCacheDir = function () {return null;};
```