### PR TITLE
Bump node-mapnik to 3.5.14 to allow building with node LTS (6.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "leaflet": "^1.0.0-rc.3",
     "leaflet-formbuilder": "^0.2.0",
     "leaflet-hash": "^0.2.1",
-    "mapnik": "3.5.13",
+    "mapnik": "3.5.14",
     "nomnom": "^1.8.1",
     "npm": "^3.10.6",
     "request": "^2.64.0",

--- a/src/back/PreviewServer.js
+++ b/src/back/PreviewServer.js
@@ -136,13 +136,12 @@ PreviewServer.prototype.serveProjectRoute = function (path, uri, res, project) {
     return this._project_routes[path].call(this, uri, res, project);
 };
 
-PreviewServer.prototype.pushToFront = function (res, anonymous) {
+PreviewServer.prototype.pushToFront = function (res, func) {
     // Ugly but GOOD
-    if (anonymous.name) throw 'Cannot use bridge helper with named function:' + anonymous.name;
     res.writeHead(200, {
         'Content-Type': 'application/javascript',
     });
-    res.write(anonymous.toString().substring(13, anonymous.toString().length - 1));
+    res.write(func.toString().substring(13, func.toString().length - 1));
     res.end();
 };
 


### PR DESCRIPTION
3.5.13 binary is not available:

```
$ http --headers 'https://mapbox-node-binary.s3.amazonaws.com/mapnik/v3.5.13/Release/node-v48-linux-x64.tar.gz'
HTTP/1.1 403 Forbidden
Content-Type: application/xml
Date: Wed, 07 Dec 2016 08:50:38 GMT
Server: AmazonS3
Transfer-Encoding: chunked
x-amz-id-2: S4cqharLL/wfY5MiW15J89DLfjnJ6kZ+WrVOZ4AkE4Ane1k9dKxdrWinrPEvLb79iHfjhJeqbB8=
x-amz-request-id: 4E6592049D9889DC
```

While it's available for 3.5.14:
```
$ http --headers 'https://mapbox-node-binary.s3.amazonaws.com/mapnik/v3.5.14/Release/node-v48-linux-x64.tar.gz'
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 22145358
Content-Type: application/octet-stream
Date: Wed, 07 Dec 2016 08:50:58 GMT
ETag: "3b3c8c7a0892c672898125baf463b7a0"
Last-Modified: Fri, 09 Sep 2016 21:08:34 GMT
Server: AmazonS3
x-amz-id-2: NOHabooaOkL4tA9vy6dZ6a1RIBCFTCV/a8Mfm9nDpxcl/DNwwL6MEJK1z9aWarC8G8aylFrqCqM=
x-amz-request-id: EE29FCA7FFFE8DC6
```

Also update pushToFront to work with Node 6.x (we should remove it as some point, this was a bad idea).