### PR TITLE
[WIP] replace nomnom by commander.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,19 +19,17 @@
   },
   "author": "Yohan Boniface",
   "license": "WTFPL",
-  "engines": {
-    "npm": ">=1.5.0"
-  },
   "dependencies": {
     "carto": "^0.17.2",
+    "commander": "^2.9.0",
     "js-yaml": "^3.4.2",
     "json-localizer": "0.0.3",
     "leaflet": "^1.0.2",
     "leaflet-formbuilder": "^0.2.0",
     "leaflet-hash": "^0.2.1",
+    "lodash.has": "^4.5.2",
     "mapnik": "3.5.14",
     "mapnik-pool": "^0.1.3",
-    "nomnom": "^1.8.1",
     "npm": "^4.0.5",
     "request": "^2.64.0",
     "semver": "^5.0.3"

--- a/src/back/PluginsManager.js
+++ b/src/back/PluginsManager.js
@@ -1,27 +1,40 @@
 var npm = require('npm'),
     fs = require('fs'),
     path = require('path'),
-    semver = require('semver');
+    semver = require('semver'),
+    _has = require('lodash.has');
 
 var PluginsManager = function (config) {
+    var self = this;
+
     this.config = config;
-    this.config.commands.plugins = this.config.opts.command('plugins');
-    this.config.commands.plugins.option('installed', {
-        flag: true,
-        help: 'Show installed plugins'
-    }).help('Manage plugins');
-    this.config.commands.plugins.option('available', {
-        flag: true,
-        help: 'Show available plugins in registry'
-    });
-    this.config.commands.plugins.option('install', {
-        metavar: 'NAME',
-        help: 'Install a plugin',
-        list: true
-    });
-    this.config.commands.plugins.option('reinstall', {
-        flag: true,
-        help: 'Reinstall every installed plugin'
+    this.config.commands.plugins = this.config.opts.command('plugins')
+        .description('Manage plugins')
+        .option('--installed',
+            'Show installed plugins')
+        .option('--available',
+            'Show available plugins in registry')
+        .option('--install <name>',
+            'Install a plugin',
+            function (val) {
+                return val.split(',');
+        })
+        .option('--reinstall',
+            'Reinstall every installed plugin')
+        .action(function (options) {
+            if (_has(options, 'installed')) {
+                self.config.parsed_opts.installed = true;
+            }
+            if (_has(options, 'available')) {
+                self.config.parsed_opts.available = options.available;
+            }
+            if (_has(options, 'install')) {
+                self.config.parsed_opts.install = options.install;
+            }
+            if (_has(options, 'reinstall')) {
+                self.config.parsed_opts.reinstall = options.reinstall;
+            }
+            self.config.parsed_opts.commandName = 'plugins';
     });
     this.config.on('command:plugins', this.handleCommand.bind(this));
     this.config.beforeState('project:loaded', this.handleProject.bind(this));

--- a/src/plugins/base-exporters/index.js
+++ b/src/plugins/base-exporters/index.js
@@ -1,35 +1,11 @@
 var fs = require('fs'),
-    path = require('path');
+    path = require('path'),
+    _has = require('lodash.has');
 
 var BaseExporters = function (config) {
-    config.commands.export = config.opts.command('export').help('Export a project');
-    config.commands.export.option('project', {
-        position: 1,
-        help: 'Project to export.'
-    });
-    config.commands.export.option('output', {
-        help: 'Filepath to save in',
-        metavar: 'PATH'
-    });
-    config.commands.export.option('width', {
-        help: 'Width of the export',
-        metavar: 'INT',
-        default: 1000
-    });
-    config.commands.export.option('height', {
-        help: 'Height of the export',
-        metavar: 'INT',
-        default: 1000
-    });
-    config.commands.export.option('bounds', {
-        help: 'BBox to use [Default: project extent]',
-        metavar: 'minX,minY,maxX,maxY'
-    });
-    config.commands.export.option('scale', {
-        help: 'Scale the exported image',
-        metavar: 'INT',
-        default: 1
-    });
+    var self = this;
+    this.parsed_opts = {};
+
     config.on('command:export', this.handleCommand);
     config.registerExporter('xml', path.join(__dirname, 'XML.js'));
     config.registerExporter('mml', path.join(__dirname, 'MML.js'));
@@ -40,16 +16,82 @@ var BaseExporters = function (config) {
     config.registerExporter('png24', path.join(__dirname, 'PNG.js'));
     config.registerExporter('png32', path.join(__dirname, 'PNG.js'));
     config.registerExporter('png256', path.join(__dirname, 'PNG.js'));
-    config.on('parseopts', this.parseOpts);
     config.addJS('/src/plugins/base-exporters/front/export.js');
-};
 
-BaseExporters.prototype.parseOpts = function (e) {
-    this.commands.export.option('format', {
-        help: 'Format of the export',
-        metavar: 'FORMAT',
-        default: 'xml',
-        choices: Object.keys(this.exporters)
+    config.commands.export = config.opts.command('export <project>')
+        .description('Export a project.')
+        .option('--mapnik-version [version]',
+            'Optional mapnik reference version to be passed to Carto.',
+            config.defaultMapnikVersion())
+        .option('--keep-cache',
+            'Do not flush cached metatiles on project load.')
+        .option('--renderer [name]',
+            'Specify a renderer by its name, carto is the default.',
+            'carto')
+        .option('--metatile <metatile>',
+            'Override mml metatile setting [Default: mml setting].')
+        .option('--output <output>',
+            'Filepath to save in')
+        .option('--width [width]',
+            'Width of the export. Default: 1000',
+            parseInt,
+            1000)
+        .option('--height [height]',
+            'Height of the export. Default: 1000',
+            parseInt,
+            1000)
+        .option('--bounds <bbox>',
+            'BBox to use in format minX,minY,maxX,maxY. Default: project extent')
+        .option('--scale [scale]',
+            'Scale the exported image. Default: 1',
+            parseInt,
+            1)
+        .option('--format [format]',
+            'Format of the export. Default: xml',
+            function (val) {
+                if (val in config.exporters) {
+                    return val;
+                }
+
+                return 'xml';
+            },
+            'xml')
+        .action(function (project, options) {
+            if (_has(options, 'output')) {
+                config.parsed_opts.output = options.output;
+            }
+            if (_has(options, 'width')) {
+                config.parsed_opts.width = options.width;
+            }
+            if (_has(options, 'height')) {
+                config.parsed_opts.height = options.height;
+            }
+            if (_has(options, 'bounds')) {
+                config.parsed_opts.bounds = options.bounds;
+            }
+            if (_has(options, 'scale')) {
+                config.parsed_opts.scale = options.scale;
+            }
+            if (_has(options, 'format')) {
+                config.parsed_opts.format = options.format;
+            }
+            if (_has(options, 'renderer')) {
+                config.parsed_opts.renderer = options.renderer;
+            }
+            if (_has(options, 'metatile')) {
+                config.parsed_opts.metatile = options.metatile;
+            }
+            // since commander does not support individual variable names
+            // we have to set them manually
+            if (_has(options, 'mapnikVersion')) {
+                config.parsed_opts.mapnik_version = options.mapnikVersion;
+            }
+            if (_has(options, 'keepCache')) {
+                config.parsed_opts.keepcache = options.keepcache;
+            }
+
+            config.parsed_opts.project = project;
+            config.parsed_opts.commandName = 'export';
     });
 };
 

--- a/src/plugins/local-config/index.js
+++ b/src/plugins/local-config/index.js
@@ -3,7 +3,7 @@ var fs = require('fs'),
     Localizer = require('json-localizer').Localizer;
 
 var LocalConfig = function (config) {
-    config.opts.option('localconfig', {help: 'Path to local config file [Default: {projectpath}/localconfig.json|.js]'});
+    config.opts.option('--localconfig <path>', 'Path to local config file [Default: {projectpath}/localconfig.json|.js].');
     config.beforeState('project:loaded', this.patchMML);
 };
 


### PR DESCRIPTION
Fixes #117.

nomnom is EOL and recommends commander.js instead. Thus this tries to replace nomnom by commander.js. A few things regarding command line parsing had to change, so testing is much appreciated.

Before merging we also have to clarify how we want to handle the dependent plugins:
https://github.com/kosmtik/kosmtik-mbtiles-export/blob/master/index.js#L4
https://github.com/kosmtik/kosmtik-deploy/blob/master/index.js#L14
https://github.com/kosmtik/kosmtik-fetch-remote/blob/master/index.js#L10
https://github.com/kosmtik/kosmtik-tiles-export/blob/master/index.js#L4