### PR TITLE
changed carto package path namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Yohan Boniface",
   "license": "WTFPL",
   "dependencies": {
-    "carto": "^0.16.1",
+    "mapbox/carto": "^0.16.1",
     "generic-pool": "^2.2.0",
     "js-yaml": "^3.4.2",
     "json-localizer": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Yohan Boniface",
   "license": "WTFPL",
   "dependencies": {
-    "mapbox/carto": "^0.16.1",
+    "@mapbox/carto": "^0.16.1",
     "generic-pool": "^2.2.0",
     "js-yaml": "^3.4.2",
     "json-localizer": "0.0.3",

--- a/src/back/renderer/Carto.js
+++ b/src/back/renderer/Carto.js
@@ -1,4 +1,4 @@
-var carto = require('carto');
+var carto = require('@mapbox/carto');
 
 
 var Carto = function (project) {


### PR DESCRIPTION
npm warned me about a bad package path for carto
** please note the change is untested**

    npm WARN deprecated carto@0.15.3: This module is now under the @mapbox namespace: install @mapbox/carto instead