### PR TITLE
specify npm >= 1.5.0 as required 

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   },
   "author": "Yohan Boniface",
   "license": "WTFPL",
+  "engines": {
+    "npm": ">=1.5.0"
+  },
   "dependencies": {
     "@mapbox/carto": "^0.16.1",
     "generic-pool": "^3.1.6",


### PR DESCRIPTION
Necessary for handling scoped packages like carto.
Ref #215.