### PR TITLE
switch from mapbox carto to alacarto

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "npm": ">=1.5.0"
   },
   "dependencies": {
-    "@mapbox/carto": "^0.16.1",
+    "alacarto": "^0.18.0",
     "js-yaml": "^3.4.2",
     "json-localizer": "0.0.3",
     "leaflet": "^1.0.2",

--- a/src/back/renderer/Carto.js
+++ b/src/back/renderer/Carto.js
@@ -1,4 +1,4 @@
-var carto = require('@mapbox/carto');
+var carto = require('alacarto');
 
 
 var Carto = function (project) {


### PR DESCRIPTION
I have forked [Mapbox Carto](https://github.com/mapbox/carto) to [alacarto](https://github.com/alacarto/alacarto).

Why? I grew tired of repeatedly having to beg about publish rights on NPM. And nobody else did have the time to do releases. If you are the only developer and cannot publish the release you made this can be frustrating.

So I suggest that we switch to the forked version as the original repository will be rather unmaintained after that. Nothing changes with regard to carto, this is just a new release under a new name for now. Also there is no scoped package anymore, which should make users of NPM < 1.5 happy.

For the changes and bugfixes see the [changelog](https://github.com/alacarto/alacarto/blob/master/CHANGELOG.md).

Fixes #177.

cc @gravitystorm