### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "npm": ">=1.5.0"
   },
   "dependencies": {
-    "carto": "^0.17.2",
+    "carto": "^0.18.0",
     "js-yaml": "^3.4.2",
     "json-localizer": "0.0.3",
     "leaflet": "^1.0.2",
@@ -33,7 +33,7 @@
     "mapnik-pool": "^0.1.3",
     "nomnom": "^1.8.1",
     "npm": "^4.0.5",
-    "request": "^2.64.0",
+    "request": "^2.81.0",
     "semver": "^5.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
~~Mapnik 3.6.0 adds Node v7 support. I have tested it on Node v6 and v7 on Linux.~~
carto has no important changes.
The update to request fixes a security vulnerability.