### PR TITLE
do not forcibly set layer name

### DIFF
--- a/src/back/loader/Base.js
+++ b/src/back/loader/Base.js
@@ -29,7 +29,6 @@ BaseLoader.prototype.postprocess = function () {
 
 BaseLoader.prototype.normalizeLayer = function (layer) {
     if (!layer.srs) layer.srs = this.srs;
-    if (!layer.name) layer.name = layer.id;
     return layer;
 };
 


### PR DESCRIPTION
This is now deprecated in the MML definition. `id` should be used instead.