### PR TITLE
Change command palette shortcut to ctrl-alt-P

### DIFF
--- a/src/front/Command.js
+++ b/src/front/Command.js
@@ -20,7 +20,7 @@ L.Kosmtik.Command = L.Class.extend({
         };
         this.autocomplete = new L.K.Autocomplete(this.tool, {
             minChar: 0,
-            placeholder: 'Type command (ctrl-shift-P)…',
+            placeholder: 'Type command (ctrl-alt-P)…',
             emptyMessage: 'No matching command',
             formatResult: formatResult,
             submitDelay: 100
@@ -33,6 +33,15 @@ L.Kosmtik.Command = L.Class.extend({
         this.autocomplete.on('selected', function (e) {
             e.choice.callback.apply(e.choice.context || this._map);
         }, this);
+        this.add({
+            keyCode: L.K.Keys.P,
+            altKey: true,
+            ctrlKey: true,
+            callback: this.focus,
+            context: this,
+            name: 'Command palette: focus'
+        });
+        // Retrocompat.
         this.add({
             keyCode: L.K.Keys.P,
             shiftKey: true,


### PR DESCRIPTION
ctrl-shift-P is a Firefox built in (private mode).
We may make shortcuts customisable in the future, but let's make
it simple for now.
We keep the former one for recompatibility.

I've chosen ctrl-alt-P to keep something close and memorizable (P => palette), but I'm open to suggestions (YMMV… ;) ).