### PR TITLE
Allow to define Mapnik variables from the mml and passe them as command argument

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -149,6 +149,10 @@ Config.prototype.initOptions = function () {
     this.opts.option('metatile', {
         help: 'Override mml metatile setting [Default: mml setting]'
     });
+    this.opts.option('variable', {
+        help: 'Override mml Mapnik run-time variables, syntax is key:value, eg. --variable=lang:fr',
+        list: true
+    });
 };
 
 Config.prototype.parseOptions = function () {

--- a/src/back/Project.js
+++ b/src/back/Project.js
@@ -25,6 +25,7 @@ var Project = function (config, filepath, options) {
     this.cachePath = path.join('tmp', this.id);
     this.beforeState('loaded', this.initMetaCache);
     this.beforeState('loaded', this.initVectorCache);
+    this.beforeState('loaded', this.overrideVariables);
 };
 
 util.inherits(Project, ConfigEmitter);
@@ -140,6 +141,17 @@ Project.prototype.initVectorCache = function (e) {
         self.config.log('Created vector cache dir', dir);
         e.continue();
     });
+};
+
+Project.prototype.overrideVariables = function (e) {
+    if (this.config.parsed_opts.variable) {
+        for (var raw of this.config.parsed_opts.variable) {
+            raw = raw.split(':');
+            if (raw.length !== 2) this.config.log('WARNING Bad variable value', raw);
+            else this.mml.variables[raw[0]] = raw[1];
+        }
+    }
+    e.continue();
 };
 
 exports.Project = Project;

--- a/src/back/Tile.js
+++ b/src/back/Tile.js
@@ -31,7 +31,8 @@ Tile.prototype.render = function (project, map, cb) {
     this.setupBounds();
     map.zoomToBox(this.projection.forward([this.minX, this.minY, this.maxX, this.maxY]));
     var im = new mapnik.Image(this.height, this.width);
-    map.render(im, {scale: project.mml.scale || 1, variables: {zoom: this.z}}, cb);
+    project.mml.variables.zoom = this.z;
+    map.render(im, {scale: project.mml.scale || 1, variables: project.mml.variables}, cb);
 };
 
 Tile.prototype.renderToVector = function (project, map, cb) {

--- a/src/back/loader/Base.js
+++ b/src/back/loader/Base.js
@@ -8,6 +8,7 @@ var BaseLoader = function (project) {
 
 BaseLoader.prototype.postprocess = function () {
     this.mml.metatile = +(this.mml.metatile || (this.mml.source ? 1 : 2));  // Default vectortiles to 1, classic to 2.
+    this.mml.variables = this.mml.variables || {};
     if (this.mml.Stylesheet) {
         this.mml.Stylesheet = this.mml.Stylesheet.map(this.normalizeStylesheet.bind(this));
     }


### PR DESCRIPTION
This allows managing "substyles" in one style, for example for handling
different languages.
Say one wants to generate a same style with English labels first once and
with Arabic labels then.
In the mml, she would add a default value:

    variables:
        lang: name_en

The Layer SQL would look something like (say columns name_en and name_ar exist):

    SELECT COALESCE(@lang, name) AS lang

Now to generate (or serve/deploy…) the style with Arabic labels first, she
could run a command like:

    kosmtik export --format xml --variable=lang:lang_ar

Many other usages can be imagined from there (CartoCSS filters, SQL WHERE…)