### PR TITLE
Node.js 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "8"
   - "6"
   - "4"
 git:

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Only the core needs:
 
 ## Install or Update
 
-Note: NodeJS versions are moving very fast, and kosmtik or its dependencies are
+Note: Node.js versions are moving very fast, and kosmtik or its dependencies are
 hardly totally up to date with latest release. Ideally, you should run the LTS
-version of NodeJS. You can use a NodeJS version manager (like
+version of Node.js. You can use a Node.js version manager (like
 [NVM](https://github.com/creationix/nvm)) to help.
 
     npm -g install kosmtik

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": "./index.js",
   "preferGlobal": true,
   "scripts": {
-    "test": "node node_modules/.bin/mocha"
+    "test": "mocha"
   },
   "keywords": [
     "openstreetmap",


### PR DESCRIPTION
Hi,

Just add Node.js 8 support in Travis CI and some non-hurting fixes.

Node.js 8 will become a LTS version in the following days.
In the future, I think you should support at least active and maintained LTS versions + current version.

Example:
As of November 2017: 4 (Maintained LTS), 6 (Active LTS), 8 (Active LTS), 9 (Current)
As of May 2018: 6 (Maintained LTS), 8 (Active LTS), 10 (Current)

![Node.js LTS release schedule](https://github.com/nodejs/Release/raw/master/schedule.png)