### PR TITLE
[WIP] add support for CartoCSS 1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "npm": ">=1.5.0"
   },
   "dependencies": {
-    "carto": "^0.18.0",
+    "carto": "^1.0.0",
     "js-yaml": "^3.4.2",
     "json-localizer": "0.0.3",
     "leaflet": "^1.0.2",

--- a/src/back/renderer/Carto.js
+++ b/src/back/renderer/Carto.js
@@ -17,8 +17,24 @@ Carto.prototype.render = function () {
             mapnik_version: this.project.mml.mapnik_version || this.project.config.parsed_opts.mapnik_version
         };
     this.project.config.log('Using mapnik version', options.mapnik_version);
-    return new carto.Renderer(env, options).render(this.project.mml);
+    var output = new carto.Renderer(env, options).render(this.project.mml);
 
+    if (output.msg) {
+        output.msg.forEach(function (v) {
+            if (v.type === 'error') {
+                console.error(carto.Util.getMessageToPrint(v));
+            }
+            else if (v.type === 'warning') {
+                console.warn(carto.Util.getMessageToPrint(v));
+            }
+        });
+    }
+
+    if (output.data) {
+        return output.data;
+    }
+
+    return null;
 };
 
 exports.Renderer = Carto;


### PR DESCRIPTION
CartoCSS 1.0.0 had a breaking change in its JavaScript API. Now it is able to output warnings in addition to errors and errors are no longer emitted on stdout but returned in a special error property alongside the output data.

@yohanboniface I need your help with putting the new error output into the container that pops up at the bottom of the map. Also we need to clarify some other things. I think we would emit warnings to the console instead of to the map display. For some warnings may be too verbose, so we might want to give the user the chance to switch them off. CartoCSS supports that via a API switch, but we would need to put a similar config option into the Kosmtik config file.