### PR TITLE
Update node-mapnik to 3.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "leaflet": "^1.0.2",
     "leaflet-formbuilder": "^0.2.0",
     "leaflet-hash": "^0.2.1",
-    "mapnik": "3.7.1",
+    "mapnik": "3.7.2",
     "mapnik-pool": "^0.1.3",
     "nomnom": "^1.8.1",
     "npm": "^4.0.5",


### PR DESCRIPTION
This is more important update than what the versioning says, because it bumps Mapnik from 3.0.18 to 3.0.20, which fixes this visible bug: https://github.com/mapnik/mapnik/pull/3844 (and also [some others too](
https://github.com/mapnik/mapnik/blob/v3.0.x/CHANGELOG.md)).