### PR TITLE
Adds option --style-name

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -150,8 +150,9 @@ Config.prototype.initOptions = function () {
         help: 'Override mml metatile setting [Default: mml setting]'
     });
     this.opts.option('style_id', {
-        full: 'style-name',
-        help: 'Specify style name. Useful when multiple project.mml fies placed in one single directory. [Default: project directory name]'
+        type: 'string',
+        full: 'style-id',
+        help: 'Specify style id. Useful when multiple project.mml fies placed in one single directory. [Default: project directory name]'
     });
 };
 

--- a/src/Config.js
+++ b/src/Config.js
@@ -152,7 +152,7 @@ Config.prototype.initOptions = function () {
     this.opts.option('style_id', {
         type: 'string',
         full: 'style-id',
-        help: 'Specify style id. Useful when multiple project.mml fies placed in one single directory. [Default: project directory name]'
+        help: 'Specify style id. Useful when multiple project.mml files placed in one single directory. [Default: project directory name]'
     });
 };
 

--- a/src/Config.js
+++ b/src/Config.js
@@ -149,7 +149,7 @@ Config.prototype.initOptions = function () {
     this.opts.option('metatile', {
         help: 'Override mml metatile setting [Default: mml setting]'
     });
-    this.opts.option('style_name', {
+    this.opts.option('style_id', {
         full: 'style-name',
         help: 'Specify style name. Useful when multiple project.mml fies placed in one single directory. [Default: project directory name]'
     });

--- a/src/Config.js
+++ b/src/Config.js
@@ -149,6 +149,10 @@ Config.prototype.initOptions = function () {
     this.opts.option('metatile', {
         help: 'Override mml metatile setting [Default: mml setting]'
     });
+    this.opts.option('style_name', {
+        full: 'style-name',
+        help: 'Specify style name. Useful when multiple project.mml fies placed in one single directory. [Default: project directory name]'
+    });
 };
 
 Config.prototype.parseOptions = function () {

--- a/src/back/Project.js
+++ b/src/back/Project.js
@@ -9,7 +9,7 @@ var Project = function (config, filepath, options) {
     this.CLASSNAME = 'project';
     ConfigEmitter.call(this, config);
     this.filepath = filepath;
-    this.id = options.id || path.basename(path.dirname(fs.realpathSync(this.filepath)));
+    this.id = String(this.config.parsed_opts.style_name) || options.id || path.basename(path.dirname(fs.realpathSync(this.filepath)));
     this.root = path.dirname(path.resolve(this.filepath));
     this.dataDir = path.join(this.root, 'data');
     try {

--- a/src/back/Project.js
+++ b/src/back/Project.js
@@ -9,7 +9,7 @@ var Project = function (config, filepath, options) {
     this.CLASSNAME = 'project';
     ConfigEmitter.call(this, config);
     this.filepath = filepath;
-    this.id = String(this.config.parsed_opts.style_id) || options.id || path.basename(path.dirname(fs.realpathSync(this.filepath)));
+    this.id = this.config.parsed_opts.style_id || options.id || path.basename(path.dirname(fs.realpathSync(this.filepath)));
     this.root = path.dirname(path.resolve(this.filepath));
     this.dataDir = path.join(this.root, 'data');
     try {

--- a/src/back/Project.js
+++ b/src/back/Project.js
@@ -9,7 +9,7 @@ var Project = function (config, filepath, options) {
     this.CLASSNAME = 'project';
     ConfigEmitter.call(this, config);
     this.filepath = filepath;
-    this.id = String(this.config.parsed_opts.style_name) || options.id || path.basename(path.dirname(fs.realpathSync(this.filepath)));
+    this.id = String(this.config.parsed_opts.style_id) || options.id || path.basename(path.dirname(fs.realpathSync(this.filepath)));
     this.root = path.dirname(path.resolve(this.filepath));
     this.dataDir = path.join(this.root, 'data');
     try {

--- a/test/data/minimalist-project.xml
+++ b/test/data/minimalist-project.xml
@@ -1,25 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE Map[]>
 <Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
-
-<Parameters>
-  <Parameter name="bounds">1.2219,43.0923,1.3057,43.1517</Parameter>
-  <Parameter name="center">1.256,43.1249,16</Parameter>
-  <Parameter name="minzoom">6</Parameter>
-  <Parameter name="maxzoom">20</Parameter>
-  <Parameter name="scale">1</Parameter>
-  <Parameter name="metatile">2</Parameter>
-  <Parameter name="name"><![CDATA[ProjectName]]></Parameter>
-</Parameters>
-
-
-<Layer name="land-low"
-  srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
-    
+  <Parameters>
+    <Parameter name="bounds">1.2219,43.0923,1.3057,43.1517</Parameter>
+    <Parameter name="center">1.256,43.1249,16</Parameter>
+    <Parameter name="minzoom">6</Parameter>
+    <Parameter name="maxzoom">20</Parameter>
+    <Parameter name="scale">1</Parameter>
+    <Parameter name="metatile">2</Parameter>
+    <Parameter name="name"><![CDATA[ProjectName]]></Parameter>
+  </Parameters>
+  <Layer name="land-low" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
     <Datasource>
-       <Parameter name="file"><![CDATA[land-low.shp]]></Parameter>
-       <Parameter name="type"><![CDATA[shape]]></Parameter>
+      <Parameter name="file"><![CDATA[land-low.shp]]></Parameter>
+      <Parameter name="type"><![CDATA[shape]]></Parameter>
     </Datasource>
   </Layer>
-
 </Map>
+


### PR DESCRIPTION
Hello!
I had an issue when using multiple project.mml with caching enabled.
When project.mml files are placed in single path (for example /path/style/project*.mml), then kosmtik uses "style" as prefix to path with cached metatiles.
In such case cache of multiple styles conflicts with each other.

This MR adds possibility to specify --style-name that will be used as prefix for cached metatiles, so now we are able to run multiple kosmtik instances in such way:

```bash
node /opt/kosmtik/index.js serve --mapnik-version 3.0.19 --style-name my_style --keep-cache --port 6790 /opt/mapnik/styles/project.mml

node /opt/kosmtik/index.js serve --mapnik-version 3.0.19 --style-name my_style_en --keep-cache --port 6791 /opt/mapnik/styles/project_en.mml
```