### PR TITLE
Add version plugin with version command

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -13,12 +13,11 @@ kosmtik.src = __dirname;
 
 class Config extends StateBase {
 
-    version = packageVersion;
-
     constructor(root, configpath) {
         super();
         this.configpath = configpath;
         this.root = root;
+        this.version = packageVersion;
         this.helpers = new Helpers(this);
         this.initOptions();
         this.initExporters();

--- a/src/Config.js
+++ b/src/Config.js
@@ -6,7 +6,8 @@ var util = require('util'),
     StateBase = require('./back/StateBase.js').StateBase,
     Helpers = require('./back/Helpers.js').Helpers,
     mapnik = require('mapnik'),
-    PluginsManager = require('./back/PluginsManager.js').PluginsManager;
+    PluginsManager = require('./back/PluginsManager.js').PluginsManager,
+    packageVersion = require('../package.json').version;
 
 global.kosmtik = {};
 kosmtik.src = __dirname;
@@ -115,6 +116,7 @@ Config.prototype.getLoader = function (ext) {
 Config.prototype.initOptions = function () {
     this.opts = require('nomnom');
     this.commands = {};
+    this.commands.version = this.opts.command('version').help('Show the package version');
     this.commands.serve = this.opts.command('serve').help('Run the server');
     this.commands.serve.option('path', {
         position: 1,
@@ -232,5 +234,7 @@ Config.prototype.defaultMapnikVersion = function () {
     var version = semver(mapnik.versions.mapnik);
     return version.format();
 };
+
+Config.prototype.version = packageVersion;
 
 exports.Config = Config;

--- a/src/back/PluginsManager.js
+++ b/src/back/PluginsManager.js
@@ -29,7 +29,8 @@ var PluginsManager = function (config) {
         '../plugins/base-exporters/index.js',
         '../plugins/hash/index.js',
         '../plugins/local-config/index.js',
-        '../plugins/datasource-loader/index.js'
+        '../plugins/datasource-loader/index.js',
+        '../plugins/version/index.js',
     ].concat(this.config.userConfig.plugins || []);
     for (var i = 0; i < this._registered.length; i++) {
         this.load(this._registered[i]);

--- a/src/plugins/version/index.js
+++ b/src/plugins/version/index.js
@@ -1,0 +1,9 @@
+var Version = function (config) {
+    config.on('command:version', this.handleCommand.bind(this, config.version));
+};
+
+Version.prototype.handleCommand = function (version) {
+    console.log('Kosmtik version', version);
+};
+
+exports.Plugin = Version;

--- a/src/plugins/version/index.js
+++ b/src/plugins/version/index.js
@@ -8,4 +8,4 @@ class Version {
     }
 }
 
-exports = { Plugin: Version };
+exports = module.exports = { Plugin: Version };


### PR DESCRIPTION
This adds a command `version` that outputs the current package JSON version. This should solve #307. 

Output without any arguments:
```
[Core] No usable config file found in /home/hidde/.config/kosmtik.yml
[Core] Loading plugin from ../plugins/base-exporters/index.js
[Core] Loading plugin from ../plugins/hash/index.js
[Core] Loading plugin from ../plugins/local-config/index.js
[Core] Loading plugin from ../plugins/datasource-loader/index.js
[Core] Loading plugin from ../plugins/version/index.js

command argument is required

Usage: /usr/bin/node index.js <command> [options]

command     
  version     Show the package version
  serve       Run the server
  plugins     Manage plugins
  export      Export a project

Options:
   --port             Port to listen on.  [6789]
   --host             Host to listen on.  [127.0.0.1]
   --mapnik-version   Optional mapnik reference version to be passed to Carto  [4.0.0]
   --proxy            Optional proxy to use when doing http requests
   --keep-cache       Do not flush cached metatiles on project load
   --renderer         Specify a renderer by its name, carto is the default.  [carto]
   --metatile         Override mml metatile setting [Default: mml setting]
   --style-id         Specify style id. Useful when multiple project.mml files placed in one single directory. [Default: project directory name]
   --localconfig      Path to local config file [Default: {projectpath}/localconfig.json|.js]


```