### PR TITLE
Use Javascript class syntax

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -1,5 +1,4 @@
-var util = require('util'),
-    path = require('path'),
+var path = require('path'),
     fs = require('fs'),
     semver = require('semver'),
     yaml = require('js-yaml'),
@@ -11,226 +10,226 @@ var util = require('util'),
 global.kosmtik = {};
 kosmtik.src = __dirname;
 
-var Config = function (root, configpath) {
-    StateBase.call(this);
-    this.configpath = configpath;
-    this.root = root;
-    this.helpers = new Helpers(this);
-    this.initOptions();
-    this.initExporters();
-    this.initLoaders();
-    this.initRenderers();
-    this.initStatics();
-    if (!this.configpath) this.ensureDefaultUserConfigPath();
-    this.loadUserConfig();
-    this.pluginsManager = new PluginsManager(this);  // Do we need back ref?
-    this.emit('loaded');
-    this.on('server:init', this.attachRoutes.bind(this));
-    this.parsed_opts = {
-        renderer: 'carto'
-    };  // Default. TODO better option management.
-};
+class Config extends StateBase {
+    constructor(root, configpath) {
+        super();
+        this.configpath = configpath;
+        this.root = root;
+        this.helpers = new Helpers(this);
+        this.initOptions();
+        this.initExporters();
+        this.initLoaders();
+        this.initRenderers();
+        this.initStatics();
+        if (!this.configpath) this.ensureDefaultUserConfigPath();
+        this.loadUserConfig();
+        this.pluginsManager = new PluginsManager(this);  // Do we need back ref?
+        this.emit('loaded');
+        this.on('server:init', this.attachRoutes.bind(this));
+        this.parsed_opts = {
+            renderer: 'carto'
+        };  // Default. TODO better option management.
+    };
 
-util.inherits(Config, StateBase);
+    getUserConfigDir() {
+        var home = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
+        return path.join(home, '.config');
+    };
 
-Config.prototype.getUserConfigDir = function () {
-    var home = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
-    return path.join(home, '.config');
-};
+    getUserConfigPath() {
+        return this.configpath || path.join(this.getUserConfigDir(), 'kosmtik.yml');
+    };
 
-Config.prototype.getUserConfigPath = function () {
-    return this.configpath || path.join(this.getUserConfigDir(), 'kosmtik.yml');
-};
+    loadUserConfig() {
+        var configpath = this.getUserConfigPath(),
+            config = {};
+        try {
+            config = yaml.safeLoad(fs.readFileSync(configpath, 'utf-8')) || {};
+            this.log('Loading config from', configpath);
+        } catch (err) {
+            this.log('No usable config file found in', configpath);
+        }
+        this.userConfig = config;
+    };
 
-Config.prototype.loadUserConfig = function () {
-    var configpath = this.getUserConfigPath(),
-        config = {};
-    try {
-        config = yaml.safeLoad(fs.readFileSync(configpath, 'utf-8')) || {};
-        this.log('Loading config from', configpath);
-    } catch (err) {
-        this.log('No usable config file found in', configpath);
-    }
-    this.userConfig = config;
-};
+    saveUserConfig() {
+        var configpath = this.getUserConfigPath(),
+            self = this;
+        fs.writeFile(configpath, yaml.safeDump(this.userConfig), function (err) {
+            self.log('Saved env conf to', configpath);
+        });
+    };
 
-Config.prototype.saveUserConfig = function () {
-    var configpath = this.getUserConfigPath(),
-        self = this;
-    fs.writeFile(configpath, yaml.safeDump(this.userConfig), function (err) {
-        self.log('Saved env conf to', configpath);
-    });
-};
+    getFromUserConfig(key, fallback) {
+        return typeof this.userConfig[key] !== 'undefined' ? this.userConfig[key] : fallback;
+    };
 
-Config.prototype.getFromUserConfig = function (key, fallback) {
-    return typeof this.userConfig[key] !== 'undefined' ? this.userConfig[key] : fallback;
-};
-
-Config.prototype.ensureDefaultUserConfigPath = function () {
-    try {
-        fs.mkdirSync(this.getUserConfigDir());
-    } catch (err) {
-        if (err.code !== 'EEXIST') throw err;
-    }
-};
-
-Config.prototype.initExporters = function () {
-    this.exporters = {};
-};
-
-Config.prototype.registerExporter = function (format, path) {
-    this.exporters[format] = path;
-};
-
-Config.prototype.initRenderers = function () {
-    this.renderers = {};
-    this.registerRenderer('carto', './back/renderer/Carto.js');
-};
-
-Config.prototype.registerRenderer = function (name, path) {
-    this.renderers[name] = path;
-};
-
-Config.prototype.getRenderer = function (name) {
-    if (!this.renderers[name]) throw new Error('Unknown renderer: ' + name);
-    return require(this.renderers[name]).Renderer;
-};
-
-Config.prototype.initLoaders = function () {
-    this.loaders = {};
-    this.registerLoader('.mml', './back/loader/MML.js');
-    this.registerLoader('.yml', './back/loader/MML.js');
-    this.registerLoader('.yaml', './back/loader/MML.js');
-};
-
-Config.prototype.registerLoader = function (ext, nameOrPath) {
-    this.loaders[ext] = nameOrPath;
-};
-
-Config.prototype.getLoader = function (ext) {
-    if (!this.loaders[ext]) throw 'Unknown project config type: ' + ext;
-    return require(this.loaders[ext]).Loader;
-};
-
-Config.prototype.initOptions = function () {
-    this.opts = require('nomnom');
-    this.commands = {};
-    this.commands.serve = this.opts.command('serve').help('Run the server');
-    this.commands.serve.option('path', {
-        position: 1,
-        help: 'Optional project path to load at start.'
-    });
-    this.opts.option('port', {
-        default: 6789,
-        help: 'Port to listen on.'
-    });
-    this.opts.option('host', {
-        default: '127.0.0.1',
-        help: 'Host to listen on.'
-    });
-    this.opts.option('mapnik_version', {
-        full: 'mapnik-version',
-        default: this.defaultMapnikVersion(),
-        help: 'Optional mapnik reference version to be passed to Carto'
-    });
-    this.opts.option('proxy', {
-        help: 'Optional proxy to use when doing http requests'
-    });
-    this.opts.option('keepcache', {
-        full: 'keep-cache',
-        flag: true,
-        help: 'Do not flush cached metatiles on project load'
-    });
-    this.opts.option('renderer', {
-        full: 'renderer',
-        default: 'carto',
-        help: 'Specify a renderer by its name, carto is the default.'
-    });
-    this.opts.option('metatile', {
-        help: 'Override mml metatile setting [Default: mml setting]'
-    });
-    this.opts.option('style_id', {
-        type: 'string',
-        full: 'style-id',
-        help: 'Specify style id. Useful when multiple project.mml files placed in one single directory. [Default: project directory name]'
-    });
-};
-
-Config.prototype.parseOptions = function () {
-    // Make sure to include all formats, even the ones
-    // added by plugins.
-    this.emit('parseopts');
-    this.parsed_opts = this.opts.parse();
-    this.emit('command:' + this.parsed_opts[0]);
-};
-
-Config.prototype.initStatics = function () {
-    this._js = [
-        '/node_modules/leaflet/dist/leaflet-src.js',
-        '/node_modules/leaflet-formbuilder/Leaflet.FormBuilder.js',
-        '/src/front/Core.js',
-        '/config/',
-        './config/',
-        '/src/front/Autocomplete.js',
-        '/src/front/DataInspector.js',
-        '/src/front/MetatilesBounds.js',
-        '/src/front/Sidebar.js',
-        '/src/front/Toolbar.js',
-        '/src/front/FormBuilder.js',
-        '/src/front/Settings.js',
-        '/src/front/Command.js',
-        '/src/front/Map.js'
-    ];
-    this._css = [
-        '/node_modules/leaflet/dist/leaflet.css',
-        '/src/front/Sidebar.css',
-        '/src/front/Toolbar.css',
-        '/src/front/Core.css'
-    ];
-};
-
-Config.prototype.addJS = function (path) {
-    this._js.push(path);
-};
-
-Config.prototype.addCSS = function (path) {
-    this._css.push(path);
-};
-
-Config.prototype.toFront = function () {
-    var options = {
-        exportFormats: Object.keys(this.exporters),
-        autoReload: this.getFromUserConfig('autoReload', true),
-        backendPolling: this.getFromUserConfig('backendPolling', true),
-        showCrosshairs: this.getFromUserConfig('showCrosshairs', false),
-        dataInspectorLayers: {
-            '__all__': true
+    ensureDefaultUserConfigPath() {
+        try {
+            fs.mkdirSync(this.getUserConfigDir());
+        } catch (err) {
+            if (err.code !== 'EEXIST') throw err;
         }
     };
-    this.emit('tofront', {options: options});
-    return options;
-};
 
-Config.prototype.attachRoutes = function (e) {
-    e.server.addRoute('/config/', this.serveForFront.bind(this));
-};
+    initExporters() {
+        this.exporters = {};
+    };
 
-Config.prototype.serveForFront = function (req, res) {
-    res.writeHead(200, {
-        'Content-Type': 'application/javascript'
-    });
-    var tpl = 'L.K.Config = %;';
-    res.write(tpl.replace('%', JSON.stringify(this.toFront())));
-    res.end();
-};
+    registerExporter(format, path) {
+        this.exporters[format] = path;
+    };
 
-Config.prototype.log = function () {
-    console.warn.apply(console, Array.prototype.concat.apply(['[Core]'], arguments));
-};
+    initRenderers() {
+        this.renderers = {};
+        this.registerRenderer('carto', './back/renderer/Carto.js');
+    };
 
-Config.prototype.defaultMapnikVersion = function () {
-    var version = semver(mapnik.versions.mapnik);
-    return version.format();
-};
+    registerRenderer(name, path) {
+        this.renderers[name] = path;
+    };
 
-exports.Config = Config;
+    getRenderer(name) {
+        if (!this.renderers[name]) throw new Error('Unknown renderer: ' + name);
+        return require(this.renderers[name]).Renderer;
+    };
+
+    initLoaders() {
+        this.loaders = {};
+        this.registerLoader('.mml', './back/loader/MML.js');
+        this.registerLoader('.yml', './back/loader/MML.js');
+        this.registerLoader('.yaml', './back/loader/MML.js');
+    };
+
+    registerLoader(ext, nameOrPath) {
+        this.loaders[ext] = nameOrPath;
+    };
+
+    getLoader(ext) {
+        if (!this.loaders[ext]) throw 'Unknown project config type: ' + ext;
+        return require(this.loaders[ext]).Loader;
+    };
+
+    initOptions() {
+        this.opts = require('nomnom');
+        this.commands = {};
+        this.commands.serve = this.opts.command('serve').help('Run the server');
+        this.commands.serve.option('path', {
+            position: 1,
+            help: 'Optional project path to load at start.'
+        });
+        this.opts.option('port', {
+            default: 6789,
+            help: 'Port to listen on.'
+        });
+        this.opts.option('host', {
+            default: '127.0.0.1',
+            help: 'Host to listen on.'
+        });
+        this.opts.option('mapnik_version', {
+            full: 'mapnik-version',
+            default: this.defaultMapnikVersion(),
+            help: 'Optional mapnik reference version to be passed to Carto'
+        });
+        this.opts.option('proxy', {
+            help: 'Optional proxy to use when doing http requests'
+        });
+        this.opts.option('keepcache', {
+            full: 'keep-cache',
+            flag: true,
+            help: 'Do not flush cached metatiles on project load'
+        });
+        this.opts.option('renderer', {
+            full: 'renderer',
+            default: 'carto',
+            help: 'Specify a renderer by its name, carto is the default.'
+        });
+        this.opts.option('metatile', {
+            help: 'Override mml metatile setting [Default: mml setting]'
+        });
+        this.opts.option('style_id', {
+            type: 'string',
+            full: 'style-id',
+            help: 'Specify style id. Useful when multiple project.mml files placed in one single directory. [Default: project directory name]'
+        });
+    };
+
+    parseOptions() {
+        // Make sure to include all formats, even the ones
+        // added by plugins.
+        this.emit('parseopts');
+        this.parsed_opts = this.opts.parse();
+        this.emit('command:' + this.parsed_opts[0]);
+    };
+
+    initStatics() {
+        this._js = [
+            '/node_modules/leaflet/dist/leaflet-src.js',
+            '/node_modules/leaflet-formbuilder/Leaflet.FormBuilder.js',
+            '/src/front/Core.js',
+            '/config/',
+            './config/',
+            '/src/front/Autocomplete.js',
+            '/src/front/DataInspector.js',
+            '/src/front/MetatilesBounds.js',
+            '/src/front/Sidebar.js',
+            '/src/front/Toolbar.js',
+            '/src/front/FormBuilder.js',
+            '/src/front/Settings.js',
+            '/src/front/Command.js',
+            '/src/front/Map.js'
+        ];
+        this._css = [
+            '/node_modules/leaflet/dist/leaflet.css',
+            '/src/front/Sidebar.css',
+            '/src/front/Toolbar.css',
+            '/src/front/Core.css'
+        ];
+    };
+
+    addJS(path) {
+        this._js.push(path);
+    };
+
+    addCSS(path) {
+        this._css.push(path);
+    };
+
+    toFront() {
+        var options = {
+            exportFormats: Object.keys(this.exporters),
+            autoReload: this.getFromUserConfig('autoReload', true),
+            backendPolling: this.getFromUserConfig('backendPolling', true),
+            showCrosshairs: this.getFromUserConfig('showCrosshairs', false),
+            dataInspectorLayers: {
+                '__all__': true
+            }
+        };
+        this.emit('tofront', {options: options});
+        return options;
+    };
+
+    attachRoutes(e) {
+        e.server.addRoute('/config/', this.serveForFront.bind(this));
+    };
+
+    serveForFront(req, res) {
+        res.writeHead(200, {
+            'Content-Type': 'application/javascript'
+        });
+        var tpl = 'L.K.Config = %;';
+        res.write(tpl.replace('%', JSON.stringify(this.toFront())));
+        res.end();
+    };
+
+    log() {
+        console.warn.apply(console, Array.prototype.concat.apply(['[Core]'], arguments));
+    };
+
+    defaultMapnikVersion() {
+        var version = semver(mapnik.versions.mapnik);
+        return version.format();
+    };
+}
+
+exports = module.exports = { Config };

--- a/src/back/ConfigEmitter.js
+++ b/src/back/ConfigEmitter.js
@@ -1,19 +1,18 @@
-var util = require('util'),
-    StateBase = require('./StateBase.js').StateBase;
+var StateBase = require('./StateBase.js').StateBase;
 
-var ConfigEmitter = function (config) {
-    StateBase.call(this);
-    this.config = config;
-};
+class ConfigEmitter extends StateBase {
+    constructor(config) {
+        super();
+        this.config = config;
+    }
 
-util.inherits(ConfigEmitter, StateBase);
+    emitAndForward(type, e) {
+        this.emit(type, e);
+        e = e || {};
+        e[this.CLASSNAME] = this;
+        type = this.CLASSNAME + ':' + type;
+        StateBase.prototype.emit.call(this.config, type, e);
+    };
+}
 
-ConfigEmitter.prototype.emitAndForward = function (type, e) {
-    this.emit(type, e);
-    e = e || {};
-    e[this.CLASSNAME] = this;
-    type = this.CLASSNAME + ':' + type;
-    StateBase.prototype.emit.call(this.config, type, e);
-};
-
-exports.ConfigEmitter = ConfigEmitter;
+exports = module.exports = exports = { ConfigEmitter };

--- a/src/back/GeoUtils.js
+++ b/src/back/GeoUtils.js
@@ -1,26 +1,28 @@
 var sinh = require('./Utils.js').sinh;
 
-module.exports = {
+function zoomXYToLatLng(z, x, y) {
+    var n = Math.pow(2.0, z),
+        lonDeg = x / n * 360.0 - 180.0,
+        latRad = Math.atan(sinh(Math.PI * (1 - 2 * y / n))),
+        latDeg = latRad * 180.0 / Math.PI;
+    return [latDeg, lonDeg];
+}
 
-    zoomXYToLatLng: function (z, x, y) {
-        var n = Math.pow(2.0, z),
-            lonDeg = x / n * 360.0 - 180.0,
-            latRad = Math.atan(sinh(Math.PI * (1 - 2 * y / n))),
-            latDeg = latRad * 180.0 / Math.PI;
-        return [latDeg, lonDeg];
-    },
+function zoomLatLngToXY(z, lat, lng) {
+    var xy = zoomLatLngToFloatXY(z, lat, lng);
+    return [Math.floor(xy[0]), Math.floor(xy[1])];
+}
 
-    zoomLatLngToXY: function (z, lat, lng) {
-        var xy = module.exports.zoomLatLngToFloatXY(z, lat, lng);
-        return [Math.floor(xy[0]), Math.floor(xy[1])];
-    },
+function zoomLatLngToFloatXY(z, lat, lng){
+    var n = Math.pow(2.0, z),
+        latRad = lat / 180.0 * Math.PI,
+        y = (1.0 - Math.log(Math.tan(latRad) + (1 / Math.cos(latRad))) / Math.PI) / 2.0 * n,
+        x = ((lng + 180.0) / 360.0) * n;
+    return [x, y];
+}
 
-    zoomLatLngToFloatXY: function (z, lat, lng) {
-        var n = Math.pow(2.0, z),
-            latRad = lat / 180.0 * Math.PI,
-            y = (1.0 - Math.log(Math.tan(latRad) + (1 / Math.cos(latRad))) / Math.PI) / 2.0 * n,
-            x = ((lng + 180.0) / 360.0) * n;
-        return [x, y];
-    }
-
+exports = module.exports = {
+    zoomXYToLatLng,
+    zoomLatLngToXY,
+    zoomLatLngToFloatXY
 };

--- a/src/back/Helpers.js
+++ b/src/back/Helpers.js
@@ -1,16 +1,17 @@
 var request = require('request'),
     version = require('../../package').version;
 
+class Helpers {
+    constructor(config) {
+        this.config = config;
+    }
 
-var Helpers = function (config) {
-    this.config = config;
-};
+    request(options, callback) {
+        if(this.config.parsed_opts.proxy) options.proxy = this.config.parsed_opts.proxy;
+        if(!options.headers) options.headers = {};
+        options.headers['User-Agent'] = 'kosmtik ' + version;
+        return request(options, callback);
+    };
+}
 
-Helpers.prototype.request = function (options, callback) {
-    if(this.config.parsed_opts.proxy) options.proxy = this.config.parsed_opts.proxy;
-    if(!options.headers) options.headers = {};
-    options.headers['User-Agent'] = 'kosmtik ' + version;
-    return request(options, callback);
-};
-
-exports.Helpers = Helpers;
+exports = module.exports = { Helpers };

--- a/src/back/MetatileBasedTile.js
+++ b/src/back/MetatileBasedTile.js
@@ -3,84 +3,84 @@ var fs = require('fs'),
     Tile = require('./Tile.js').Tile,
     path = require('path');
 
-var MetatileBasedTile = function (z, x, y, options) {
-    this.z = z;
-    this.x = x;
-    this.y = y;
-    this.metatile = options.metatile || 1;
-    this.metaX = Math.floor(x / this.metatile);
-    this.metaY = Math.floor(y / this.metatile);
-    this.format = options.format || 'png';
-    this.size = options.size || 256;
-    this.mapScale = options.mapScale || 1;
-    this.options = options;
-};
+class MetatileBasedTile {
+    constructor(z, x, y, options) {
+        this.z = z;
+        this.x = x;
+        this.y = y;
+        this.metatile = options.metatile || 1;
+        this.metaX = Math.floor(x / this.metatile);
+        this.metaY = Math.floor(y / this.metatile);
+        this.format = options.format || 'png';
+        this.size = options.size || 256;
+        this.mapScale = options.mapScale || 1;
+        this.options = options;
+    }
 
-MetatileBasedTile.prototype.render = function (project, map, cb) {
-    var self = this, basePath = project.getMetaCacheDir(),
-        baseName = this.z + '.' + this.metaX + '.' + this.metaY + 'x' + this.mapScale,
-        metaPath = path.join(basePath,  baseName + '.meta'),
-        lockPath = path.join(basePath, baseName + '.lock');
+    render(project, map, cb) {
+        var self = this, basePath = project.getMetaCacheDir(),
+            baseName = this.z + '.' + this.metaX + '.' + this.metaY + 'x' + this.mapScale,
+            metaPath = path.join(basePath,  baseName + '.meta'),
+            lockPath = path.join(basePath, baseName + '.lock');
 
-    fs.readFile(metaPath, function (err, data) {
-        if (err) {
-            if (err.code !== 'ENOENT') return cb(err);
-            fs.writeFile(lockPath, '', {flag: 'wx'}, function (err) {
-                if (err && err.code === 'EEXIST') {
-                    try {
-                        var watcher = fs.watch(lockPath);
-                        watcher.on('change', function (event) {  // Someone else is building the metatile, keep calm and wait.
-                            if (event === 'rename') { // lock has been deleted
-                                watcher.close();
-                                self.render(project, map, cb);  // Try again
-                            }
-                            // else just wait again
+        fs.readFile(metaPath, function (err, data) {
+            if (err) {
+                if (err.code !== 'ENOENT') return cb(err);
+                fs.writeFile(lockPath, '', {flag: 'wx'}, function (err) {
+                    if (err && err.code === 'EEXIST') {
+                        try {
+                            var watcher = fs.watch(lockPath);
+                            watcher.on('change', function (event) {  // Someone else is building the metatile, keep calm and wait.
+                                if (event === 'rename') { // lock has been deleted
+                                    watcher.close();
+                                    self.render(project, map, cb);  // Try again
+                                }
+                                // else just wait again
+                            });
+                        } catch (err) {
+                            if (err.code !== 'ENOENT') return cb(err);
+                        }
+                    } else if (err) {
+                        return cb(err);
+                    } else  {
+                        self.renderMetatile(metaPath, project, map, function (err, buffer) {
+                            fs.unlink(lockPath, function (err2) {
+                                if (err) return cb(err);
+                                if (err2 && err2.code !== 'ENOENT') return cb(err2);
+                                self.extractFromBytes(buffer, cb);
+                            });
                         });
-                    } catch (err) {
-                        if (err.code !== 'ENOENT') return cb(err);
                     }
-                } else if (err) {
-                    return cb(err);
-                } else  {
-                    self.renderMetatile(metaPath, project, map, function (err, buffer) {
-                        fs.unlink(lockPath, function (err2) {
-                            if (err) return cb(err);
-                            if (err2 && err2.code !== 'ENOENT') return cb(err2);
-                            self.extractFromBytes(buffer, cb);
-                        });
-                    });
-                }
-            });
-        } else {
-            self.extractFromBytes(data, cb);
-        }
-    });
+                });
+            } else {
+                self.extractFromBytes(data, cb);
+            }
+        });
+    }
 
-};
-
-MetatileBasedTile.prototype.extractFromBytes = function (buffer, cb) {
-    var self = this;
-    mapnik.Image.fromBytes(buffer, function (err, im) {
-        if (err) return cb(err);
-        var view = im.view(self.size * (self.x % self.metatile), self.size * (self.y % self.metatile), self.size, self.size);
-        cb(null, view);
-    });
-
-};
-
-MetatileBasedTile.prototype.renderMetatile = function (metaPath, project, map, cb) {
-    var self = this;
-    var tile = new Tile(self.z, self.metaX, self.metaY, {size: this.metatile * this.size, scale: this.metatile, mapScale: this.mapScale});
-    tile.render(project, map, function (err, im) {
-        if (err) return cb(err);
-        im.encode(self.format, function (err, buffer) {
+    extractFromBytes(buffer, cb) {
+        var self = this;
+        mapnik.Image.fromBytes(buffer, function (err, im) {
             if (err) return cb(err);
-            fs.writeFile(metaPath, buffer, {flag: 'wx'}, function (err) {
-                if (err && err.code !== 'EEXIST') return cb(err);
-                cb(null, buffer);
+            var view = im.view(self.size * (self.x % self.metatile), self.size * (self.y % self.metatile), self.size, self.size);
+            cb(null, view);
+        });
+    }
+
+    renderMetatile(metaPath, project, map, cb) {
+        var self = this;
+        var tile = new Tile(self.z, self.metaX, self.metaY, {size: this.metatile * this.size, scale: this.metatile, mapScale: this.mapScale});
+        tile.render(project, map, function (err, im) {
+            if (err) return cb(err);
+            im.encode(self.format, function (err, buffer) {
+                if (err) return cb(err);
+                fs.writeFile(metaPath, buffer, {flag: 'wx'}, function (err) {
+                    if (err && err.code !== 'EEXIST') return cb(err);
+                    cb(null, buffer);
+                });
             });
         });
-    });
-};
+    };
+}
 
-exports.Tile = MetatileBasedTile;
+exports = module.exports = { Tile: MetatileBasedTile };

--- a/src/back/PluginsManager.js
+++ b/src/back/PluginsManager.js
@@ -3,174 +3,176 @@ var npm = require('npm'),
     path = require('path'),
     semver = require('semver');
 
-var PluginsManager = function (config) {
-    this.config = config;
-    this.config.commands.plugins = this.config.opts.command('plugins');
-    this.config.commands.plugins.option('installed', {
-        flag: true,
-        help: 'Show installed plugins'
-    }).help('Manage plugins');
-    this.config.commands.plugins.option('available', {
-        flag: true,
-        help: 'Show available plugins in registry'
-    });
-    this.config.commands.plugins.option('install', {
-        metavar: 'NAME',
-        help: 'Install a plugin',
-        list: true
-    });
-    this.config.commands.plugins.option('reinstall', {
-        flag: true,
-        help: 'Reinstall every installed plugin'
-    });
-    this.config.on('command:plugins', this.handleCommand.bind(this));
-    this.config.beforeState('project:loaded', this.handleProject.bind(this));
-    this._registered = [
-        '../plugins/base-exporters/index.js',
-        '../plugins/hash/index.js',
-        '../plugins/local-config/index.js',
-        '../plugins/datasource-loader/index.js'
-    ].concat(this.config.userConfig.plugins || []);
-    for (var i = 0; i < this._registered.length; i++) {
-        this.load(this._registered[i]);
-    }
-};
-
-PluginsManager.prototype.load = function (name_or_path) {
-    var Plugin;
-    try {
-        Plugin = require(name_or_path).Plugin;
-    } catch (err) {
-        this.config.log('Unable to load plugin', name_or_path, err.code);
-        this.config.log('→ try: node index.js plugins --install', name_or_path);
-        return;
-    }
-    this.config.log('Loading plugin from', name_or_path);
-    new Plugin(this.config);
-};
-
-PluginsManager.prototype.each = function (method, context) {
-    for (var i = 0; i < this._registered.length; i++) {
-        method.call(context || this, this._registered[i]);
-    }
-};
-
-PluginsManager.prototype.isInstalled = function (name) {
-    return this._registered.indexOf(name) !== -1;
-};
-
-PluginsManager.prototype.isLocal = function (name) {
-    return name.indexOf('/') !== -1;
-};
-
-PluginsManager.prototype.loadPackage = function () {
-    return JSON.parse(fs.readFileSync(path.join(this.config.root, 'package.json')));
-};
-
-PluginsManager.prototype.available = function (callback) {
-    console.error('"available" is broken because "npm search" is broken, sorry.');
-    console.error('See https://github.com/npm/npm/issues/6016.');
-    return;
-    npm.load(this.loadPackage(), function () {
-        npm.commands.search(['kosmtik'], true, function (err, results) {
-            if (err) return callback(err);
-            var plugin, plugins = [];
-            for (var name in results) {
-                plugin = results[name];
-                if (plugin.keywords.indexOf('kosmtik') === -1) continue;
-                plugins.push(plugin);
-            }
-            callback(null, plugins);
+class PluginsManager {
+    constructor(config) {
+        this.config = config;
+        this.config.commands.plugins = this.config.opts.command('plugins');
+        this.config.commands.plugins.option('installed', {
+            flag: true,
+            help: 'Show installed plugins'
+        }).help('Manage plugins');
+        this.config.commands.plugins.option('available', {
+            flag: true,
+            help: 'Show available plugins in registry'
         });
-    });
+        this.config.commands.plugins.option('install', {
+            metavar: 'NAME',
+            help: 'Install a plugin',
+            list: true
+        });
+        this.config.commands.plugins.option('reinstall', {
+            flag: true,
+            help: 'Reinstall every installed plugin'
+        });
+        this.config.on('command:plugins', this.handleCommand.bind(this));
+        this.config.beforeState('project:loaded', this.handleProject.bind(this));
+        this._registered = [
+            '../plugins/base-exporters/index.js',
+            '../plugins/hash/index.js',
+            '../plugins/local-config/index.js',
+            '../plugins/datasource-loader/index.js'
+        ].concat(this.config.userConfig.plugins || []);
+        for (var i = 0; i < this._registered.length; i++) {
+            this.load(this._registered[i]);
+        }
+    };
 
-};
+    load(name_or_path) {
+        var Plugin;
+        try {
+            Plugin = require(name_or_path).Plugin;
+        } catch (err) {
+            this.config.log('Unable to load plugin', name_or_path, err.code);
+            this.config.log('→ try: node index.js plugins --install', name_or_path);
+            return;
+        }
+        this.config.log('Loading plugin from', name_or_path);
+        new Plugin(this.config);
+    };
 
-PluginsManager.prototype.install = function (names) {
-    var self = this,
-        pkg = this.loadPackage(),
-        i = 0;
-    var loopInstall = function () {
-        var name = names[i++];
-        if (!name) return;
-        self.config.log('Starting installation of ' + name);
-        npm.load(pkg, function () {
-            npm.commands.view([name], true, function (err, data) {
-                if (err) throw err.message;
-                var version = Object.keys(data)[0];
-                if (!version) return self.config.log('Not found', name, 'ABORTING');
-                var plugin = data[version];
-                if (!plugin.kosmtik || !semver.satisfies(pkg.version, plugin.kosmtik)) {
-                    return self.config.log('Unable to install', name, 'version', plugin.kosmtik, 'does not satisfy local kosmtik install', pkg.version, 'ABORTING');
+    each(method, context) {
+        for (var i = 0; i < this._registered.length; i++) {
+            method.call(context || this, this._registered[i]);
+        }
+    };
+
+    isInstalled(name) {
+        return this._registered.indexOf(name) !== -1;
+    };
+
+    isLocal(name) {
+        return name.indexOf('/') !== -1;
+    };
+
+    loadPackage() {
+        return JSON.parse(fs.readFileSync(path.join(this.config.root, 'package.json')));
+    };
+
+    available(callback) {
+        console.error('"available" is broken because "npm search" is broken, sorry.');
+        console.error('See https://github.com/npm/npm/issues/6016.');
+        return;
+        npm.load(this.loadPackage(), function () {
+            npm.commands.search(['kosmtik'], true, function (err, results) {
+                if (err) return callback(err);
+                var plugin, plugins = [];
+                for (var name in results) {
+                    plugin = results[name];
+                    if (plugin.keywords.indexOf('kosmtik') === -1) continue;
+                    plugins.push(plugin);
                 }
-                npm.commands.install([name], function (err) {
-                    if (err) return self.config.log('Error when installing package', name, err);
-                    self.config.log('Successfully installed package', name);
-                    self.attach(plugin.name);
-                    self.config.saveUserConfig();
-                    loopInstall();
+                callback(null, plugins);
+            });
+        });
+
+    };
+
+    install(names) {
+        var self = this,
+            pkg = this.loadPackage(),
+            i = 0;
+        var loopInstall = function () {
+            var name = names[i++];
+            if (!name) return;
+            self.config.log('Starting installation of ' + name);
+            npm.load(pkg, function () {
+                npm.commands.view([name], true, function (err, data) {
+                    if (err) throw err.message;
+                    var version = Object.keys(data)[0];
+                    if (!version) return self.config.log('Not found', name, 'ABORTING');
+                    var plugin = data[version];
+                    if (!plugin.kosmtik || !semver.satisfies(pkg.version, plugin.kosmtik)) {
+                        return self.config.log('Unable to install', name, 'version', plugin.kosmtik, 'does not satisfy local kosmtik install', pkg.version, 'ABORTING');
+                    }
+                    npm.commands.install([name], function (err) {
+                        if (err) return self.config.log('Error when installing package', name, err);
+                        self.config.log('Successfully installed package', name);
+                        self.attach(plugin.name);
+                        self.config.saveUserConfig();
+                        loopInstall();
+                    });
                 });
             });
-        });
+        };
+        loopInstall();
     };
-    loopInstall();
-};
 
-PluginsManager.prototype.reinstall = function () {
-    var names = [];
-    this.each(function (name) {
-        if (!this.isLocal(name)) names.push(name);
-    });
-    this.install(names);
-};
-
-PluginsManager.prototype.attach = function (name) {
-    // Attach plugin to user config
-    this.config.userConfig.plugins = this.config.userConfig.plugins || [];
-    if (this.config.userConfig.plugins.indexOf(name) === -1) this.config.userConfig.plugins.push(name);
-    this.config.log('Attached plugin:', name);
-};
-
-PluginsManager.prototype.handleCommand = function () {
-    var self = this, installed;
-    if (this.config.parsed_opts.installed) {
-        console.log('Installed plugins');
-        for (var i = 0; i < this._registered.length; i++) {
-            console.log(this._registered[i]);
-        }
-    } else if (this.config.parsed_opts.available) {
-        console.log('Loading available plugins…');
-        this.available(function (err, plugins) {
-            if (err) throw err.message;
-            for (var i = 0, plugin; i < plugins.length; i++) {
-                plugin = plugins[i];
-                installed = self.isInstalled(plugin.name) ? '✓ ' : '. ';
-                console.log(installed, plugin.name, '(' + plugin.description + ')');
-            }
+    reinstall() {
+        var names = [];
+        this.each(function (name) {
+            if (!this.isLocal(name)) names.push(name);
         });
-    } else if (this.config.parsed_opts.install) {
-        this.install(this.config.parsed_opts.install);
-    } else if (this.config.parsed_opts.reinstall) {
-        this.reinstall();
-    }
-};
+        this.install(names);
+    };
 
-PluginsManager.prototype.handleProject = function (e) {
-    var self = this;
-    if ('kosmtik' in e.project.mml && 'plugins' in e.project.mml.kosmtik) {
-        var warn = e.project.mml.kosmtik.plugins
-            .filter(function(plugin) {
-                var installed = self.isInstalled(plugin);
-                if (!installed) {
-                    self.install([plugin]);
-                    return true;
+    attach(name) {
+        // Attach plugin to user config
+        this.config.userConfig.plugins = this.config.userConfig.plugins || [];
+        if (this.config.userConfig.plugins.indexOf(name) === -1) this.config.userConfig.plugins.push(name);
+        this.config.log('Attached plugin:', name);
+    };
+
+    handleCommand() {
+        var self = this, installed;
+        if (this.config.parsed_opts.installed) {
+            console.log('Installed plugins');
+            for (var i = 0; i < this._registered.length; i++) {
+                console.log(this._registered[i]);
+            }
+        } else if (this.config.parsed_opts.available) {
+            console.log('Loading available plugins…');
+            this.available(function (err, plugins) {
+                if (err) throw err.message;
+                for (var i = 0, plugin; i < plugins.length; i++) {
+                    plugin = plugins[i];
+                    installed = self.isInstalled(plugin.name) ? '✓ ' : '. ';
+                    console.log(installed, plugin.name, '(' + plugin.description + ')');
                 }
             });
-        if (warn) {
-            self.config.log('Please relaunch the server to make sure all plugins are properly loaded.');
+        } else if (this.config.parsed_opts.install) {
+            this.install(this.config.parsed_opts.install);
+        } else if (this.config.parsed_opts.reinstall) {
+            this.reinstall();
         }
-    }
-    e.continue();
-};
+    };
 
-exports.PluginsManager = PluginsManager;
+    handleProject(e) {
+        var self = this;
+        if ('kosmtik' in e.project.mml && 'plugins' in e.project.mml.kosmtik) {
+            var warn = e.project.mml.kosmtik.plugins
+                .filter(function(plugin) {
+                    var installed = self.isInstalled(plugin);
+                    if (!installed) {
+                        self.install([plugin]);
+                        return true;
+                    }
+                });
+            if (warn) {
+                self.config.log('Please relaunch the server to make sure all plugins are properly loaded.');
+            }
+        }
+        e.continue();
+    };
+}
+
+exports = module.exports = { PluginsManager };

--- a/src/back/PreviewServer.js
+++ b/src/back/PreviewServer.js
@@ -20,8 +20,8 @@ var http = require('http'),
 
 class PreviewServer extends ConfigEmitter {
     constructor(config, root, options) {
-        this.CLASSNAME = 'server';
         super(config);
+        this.CLASSNAME = 'server';
         this.config.server = this;
         this.initRoutes();
         options = options || {};

--- a/src/back/PreviewServer.js
+++ b/src/back/PreviewServer.js
@@ -1,7 +1,6 @@
 var http = require('http'),
     url = require('url'),
     fs = require('fs'),
-    util = require('util'),
     path = require('path'),
     ConfigEmitter = require('./ConfigEmitter.js').ConfigEmitter,
     Project = require('./Project.js').Project,
@@ -19,138 +18,138 @@ var http = require('http'),
         '.ico' : 'image/x-icon'
     };
 
-var PreviewServer = function (config, root, options) {
-    this.CLASSNAME = 'server';
-    ConfigEmitter.call(this, config);
-    this.config.server = this;
-    this.initRoutes();
-    options = options || {};
-    this.projects = {};
-    this.server = http.createServer();
-    this.server.on('request', this.serve.bind(this));
-    this.server.timeout = 0;
-    this.root = root;
-    this.emitAndForward('init');
-    this.config.on('command:serve', this.listen.bind(this));
-};
+class PreviewServer extends ConfigEmitter {
+    constructor(config, root, options) {
+        this.CLASSNAME = 'server';
+        super(config);
+        this.config.server = this;
+        this.initRoutes();
+        options = options || {};
+        this.projects = {};
+        this.server = http.createServer();
+        this.server.on('request', this.serve.bind(this));
+        this.server.timeout = 0;
+        this.root = root;
+        this.emitAndForward('init');
+        this.config.on('command:serve', this.listen.bind(this));
+    };
 
-util.inherits(PreviewServer, ConfigEmitter);
-
-PreviewServer.prototype.listen = function () {
-    if (this.config.parsed_opts.path) {
-        var project = new Project(this.config, this.config.parsed_opts.path);
-        this.registerProject(project);
-        this.setDefaultProject(project);
-    }
-    this.server.listen(this.config.parsed_opts.port, this.config.parsed_opts.host);
-    this.config.log('PreviewServer started, you can browse http://' + this.config.parsed_opts.host + ':' + this.config.parsed_opts.port);
-    this.emitAndForward('listen');
-};
-
-PreviewServer.prototype.registerProject = function (project) {
-    this.projects[project.id] = new ProjectServer(project, this);  // TODO avoid cross ref
-};
-
-PreviewServer.prototype.setDefaultProject = function (project) {
-    this.defaultProject = project;
-};
-
-PreviewServer.prototype.serve = function (req, res) {
-    res.on('finish', function () {
-        // 204 are empty responses from poller, do not pollute
-        if (this.statusCode !== 204) console.warn('[httpserver]', req.url, this.statusCode);
-    });
-    var uri = url.parse(req.url, true),
-        urlpath = uri.pathname,
-        els = urlpath.split('/');
-    if (urlpath === '/') this.serveHome(uri, req, res);
-    else if (this.hasRoute(urlpath)) this._routes[urlpath].call(this, req, res);
-    else if (this.projects[els[1]]) this.forwardToProject(uri, els[1], req, res);
-    else this.serveFile(urlpath, res);
-};
-
-PreviewServer.prototype.forwardToProject = function (uri, id, req, res) {
-    uri.pathname = uri.pathname.replace('/' + id, '');
-    this.projects[id].serve(uri, req, res);
-};
-
-PreviewServer.prototype.serveHome = function (uri, req, res) {
-    // Go to project for now
-    if (this.defaultProject) return this.redirect(this.defaultProject.id, res);
-    return this.serveFile(path.join(kosmtik.src, 'front/index.html'), res);
-};
-
-PreviewServer.prototype.redirect = function (newuri, res) {
-    res.writeHead(302, {'Location': newuri, 'Cache-Control': 'private, no-cache, must-revalidate'});
-    res.end();
-};
-
-PreviewServer.prototype.serveFile = function (filepath, res) {
-    var self = this,
-        ext = path.extname(filepath);
-    if (!MIMES[ext]) return this.notFound(filepath, res);
-    
-    //we also want to find the files if the modules where deduped by npm 3+
-    if(filepath.startsWith('/node_modules/')) {
-        filepath = require.resolve(filepath.substr(14));
-    } else {
-        filepath = path.join(this.root, filepath);
-    }
-    
-    fs.exists(filepath, function(exists) {
-        if (exists) {
-            fs.readFile(filepath, function(err, contents) {
-                if(!err) {
-                    res.writeHead(200, {
-                        'Content-Type': MIMES[ext],
-                        'Content-Length' : contents.length
-                    });
-                    res.end(contents);
-                }
-            });
-        } else {
-            self.notFound(filepath, res);
+    listen() {
+        if (this.config.parsed_opts.path) {
+            var project = new Project(this.config, this.config.parsed_opts.path);
+            this.registerProject(project);
+            this.setDefaultProject(project);
         }
-    });
-};
+        this.server.listen(this.config.parsed_opts.port, this.config.parsed_opts.host);
+        this.config.log('PreviewServer started, you can browse http://' + this.config.parsed_opts.host + ':' + this.config.parsed_opts.port);
+        this.emitAndForward('listen');
+    };
 
-PreviewServer.prototype.notFound = function (filepath, res) {
-    res.writeHead(404);
-    res.end('Not Found: ' + filepath);
-};
+    registerProject(project) {
+        this.projects[project.id] = new ProjectServer(project, this);  // TODO avoid cross ref
+    };
 
-PreviewServer.prototype.initRoutes = function () {
-    this._routes = {};
-    this._project_routes = {};
-};
+    setDefaultProject(project) {
+        this.defaultProject = project;
+    };
 
-PreviewServer.prototype.addRoute = function (path, callback) {
-    this._routes[path] = callback;
-};
+    serve(req, res) {
+        res.on('finish', function () {
+            // 204 are empty responses from poller, do not pollute
+            if (this.statusCode !== 204) console.warn('[httpserver]', req.url, this.statusCode);
+        });
+        var uri = url.parse(req.url, true),
+            urlpath = uri.pathname,
+            els = urlpath.split('/');
+        if (urlpath === '/') this.serveHome(uri, req, res);
+        else if (this.hasRoute(urlpath)) this._routes[urlpath].call(this, req, res);
+        else if (this.projects[els[1]]) this.forwardToProject(uri, els[1], req, res);
+        else this.serveFile(urlpath, res);
+    };
 
-PreviewServer.prototype.hasRoute = function (path) {
-    return !!this._routes[path];
-};
+    forwardToProject(uri, id, req, res) {
+        uri.pathname = uri.pathname.replace('/' + id, '');
+        this.projects[id].serve(uri, req, res);
+    };
 
-PreviewServer.prototype.addProjectRoute = function (path, callback) {
-    this._project_routes[path] = callback;
-};
+    serveHome(uri, req, res) {
+        // Go to project for now
+        if (this.defaultProject) return this.redirect(this.defaultProject.id, res);
+        return this.serveFile(path.join(kosmtik.src, 'front/index.html'), res);
+    };
 
-PreviewServer.prototype.hasProjectRoute = function (path) {
-    return !!this._project_routes[path];
-};
+    redirect(newuri, res) {
+        res.writeHead(302, {'Location': newuri, 'Cache-Control': 'private, no-cache, must-revalidate'});
+        res.end();
+    };
 
-PreviewServer.prototype.serveProjectRoute = function (path, uri, req, res, project) {
-    return this._project_routes[path].call(this, uri, req, res, project, this);
-};
+    serveFile(filepath, res) {
+        var self = this,
+            ext = path.extname(filepath);
+        if (!MIMES[ext]) return this.notFound(filepath, res);
+        
+        //we also want to find the files if the modules where deduped by npm 3+
+        if(filepath.startsWith('/node_modules/')) {
+            filepath = require.resolve(filepath.substr(14));
+        } else {
+            filepath = path.join(this.root, filepath);
+        }
+        
+        fs.exists(filepath, function(exists) {
+            if (exists) {
+                fs.readFile(filepath, function(err, contents) {
+                    if(!err) {
+                        res.writeHead(200, {
+                            'Content-Type': MIMES[ext],
+                            'Content-Length' : contents.length
+                        });
+                        res.end(contents);
+                    }
+                });
+            } else {
+                self.notFound(filepath, res);
+            }
+        });
+    };
 
-PreviewServer.prototype.pushToFront = function (res, func) {
-    // Ugly but GOOD
-    res.writeHead(200, {
-        'Content-Type': 'application/javascript',
-    });
-    res.write(func.toString().substring(13, func.toString().length - 1));
-    res.end();
-};
+    notFound(filepath, res) {
+        res.writeHead(404);
+        res.end('Not Found: ' + filepath);
+    };
 
-exports.PreviewServer = PreviewServer;
+    initRoutes() {
+        this._routes = {};
+        this._project_routes = {};
+    };
+
+    addRoute(path, callback) {
+        this._routes[path] = callback;
+    };
+
+    hasRoute(path) {
+        return !!this._routes[path];
+    };
+
+    addProjectRoute(path, callback) {
+        this._project_routes[path] = callback;
+    };
+
+    hasProjectRoute(path) {
+        return !!this._project_routes[path];
+    };
+
+    serveProjectRoute(path, uri, req, res, project) {
+        return this._project_routes[path].call(this, uri, req, res, project, this);
+    };
+
+    pushToFront(res, func) {
+        // Ugly but GOOD
+        res.writeHead(200, {
+            'Content-Type': 'application/javascript',
+        });
+        res.write(func.toString().substring(13, func.toString().length - 1));
+        res.end();
+    };
+}
+
+exports = module.exports = { PreviewServer };

--- a/src/back/Project.js
+++ b/src/back/Project.js
@@ -5,9 +5,9 @@ var path = require('path'),
 
 class Project extends ConfigEmitter {
     constructor(config, filepath, options) {
+        super(config);
         options = options || {};
         this.CLASSNAME = 'project';
-        super(config);
         this.filepath = filepath;
         this.id = this.config.parsed_opts.style_id || options.id || path.basename(path.dirname(fs.realpathSync(this.filepath)));
         this.root = path.dirname(path.resolve(this.filepath));

--- a/src/back/Project.js
+++ b/src/back/Project.js
@@ -1,145 +1,144 @@
-var util = require('util'),
-    path = require('path'),
+var path = require('path'),
     fs = require('fs'),
     ConfigEmitter = require('./ConfigEmitter.js').ConfigEmitter,
     Utils = require('./Utils.js');
 
-var Project = function (config, filepath, options) {
-    options = options || {};
-    this.CLASSNAME = 'project';
-    ConfigEmitter.call(this, config);
-    this.filepath = filepath;
-    this.id = this.config.parsed_opts.style_id || options.id || path.basename(path.dirname(fs.realpathSync(this.filepath)));
-    this.root = path.dirname(path.resolve(this.filepath));
-    this.dataDir = path.join(this.root, 'data');
-    try {
-        fs.mkdirSync(this.dataDir);
-    } catch (err) {}
-    this.mapnik = require('mapnik');
-    this.mapnikPool = require('mapnik-pool')(this.mapnik);
-    this.mapnik.register_default_fonts();
-    this.mapnik.register_system_fonts();
-    this.mapnik.register_default_input_plugins();
-    this.mapnik.register_fonts(path.join(path.dirname(filepath), 'fonts'), {recurse: true});
-    this.changeState('init');
-    this.cachePath = path.join('tmp', this.id);
-    this.beforeState('loaded', this.initMetaCache);
-    this.beforeState('loaded', this.initVectorCache);
-};
-
-util.inherits(Project, ConfigEmitter);
-
-Project.prototype.load = function (force) {
-    if (this.mml && !force) return this.mml;
-    this.config.log('Loading project from', this.filepath);
-    var ext = path.extname(this.filepath),
-        Loader = this.config.getLoader(ext),
-        loader = new Loader(this);
-    this.mml = loader.load();
-    this.loadTime = Date.now();
-    this.changeState('loaded');
-    return this.mml;
-};
-
-Project.prototype.reload = function () {
-    // TODO Handle concurrency
-    this.xml = null;
-    this.load(true);
-};
-
-Project.prototype.render = function (force) {
-    if (this.xml && !force) return this.xml;
-    this.load(force);
-    var renderer, Renderer;
-    Renderer = this.config.getRenderer(this.config.parsed_opts.renderer);
-
-    renderer = new Renderer(this);
-    this.config.log('Generating Mapnik XML…');
-    this.xml = renderer.render();
-    return this.xml;
-};
-
-Project.prototype.createMapPool = function (options) {
-    options = options || {};
-    this.render();
-    this.config.log('Loading map…');
-    if (!options.bufferSize) options.bufferSize = this.mml.bufferSize || 256;
-    if(!options.size) options.size = this.metatileSize() * (options.scale || 1);
-    this.mapPool = this.mapnikPool.fromString(this.xml, options, {base: this.root});
-    this.config.log('Map ready');
-    return this.mapPool;
-};
-
-Project.prototype.export = function (options, callback) {
-    var format = options.format;
-    if (!this.config.exporters[format]) throw 'Unknown format ' + format;
-    var Exporter = require(this.config.exporters[format]).Exporter;
-    var exporter = new Exporter(this, options);
-    exporter.export(callback);
-};
-
-Project.prototype.toFront = function () {
-    var options = {
-        center: [this.mml.center[1], this.mml.center[0]],
-        zoom: this.mml.center[2],
-        minZoom: this.mml.minzoom,
-        maxZoom: this.mml.maxzoom,
-        metatile: this.metatile(),
-        name: this.mml.name || '',
-        tileSize: this.tileSize(),
-        loadTime: this.loadTime,
-        layers: this.mml.Layer || []
+class Project extends ConfigEmitter {
+    constructor(config, filepath, options) {
+        options = options || {};
+        this.CLASSNAME = 'project';
+        super(config);
+        this.filepath = filepath;
+        this.id = this.config.parsed_opts.style_id || options.id || path.basename(path.dirname(fs.realpathSync(this.filepath)));
+        this.root = path.dirname(path.resolve(this.filepath));
+        this.dataDir = path.join(this.root, 'data');
+        try {
+            fs.mkdirSync(this.dataDir);
+        } catch (err) {}
+        this.mapnik = require('mapnik');
+        this.mapnikPool = require('mapnik-pool')(this.mapnik);
+        this.mapnik.register_default_fonts();
+        this.mapnik.register_system_fonts();
+        this.mapnik.register_default_input_plugins();
+        this.mapnik.register_fonts(path.join(path.dirname(filepath), 'fonts'), {recurse: true});
+        this.changeState('init');
+        this.cachePath = path.join('tmp', this.id);
+        this.beforeState('loaded', this.initMetaCache);
+        this.beforeState('loaded', this.initVectorCache);
     };
-    this.emitAndForward('tofront', {options: options});
-    return options;
-};
 
-Project.prototype.tileSize = function () {
-    return 256;
-};
+    load(force) {
+        if (this.mml && !force) return this.mml;
+        this.config.log('Loading project from', this.filepath);
+        var ext = path.extname(this.filepath),
+            Loader = this.config.getLoader(ext),
+            loader = new Loader(this);
+        this.mml = loader.load();
+        this.loadTime = Date.now();
+        this.changeState('loaded');
+        return this.mml;
+    };
 
-Project.prototype.metatileSize = function () {
-    return this.tileSize() * this.metatile();
-};
+    reload() {
+        // TODO Handle concurrency
+        this.xml = null;
+        this.load(true);
+    };
 
-Project.prototype.metatile = function () {
-    return this.config.parsed_opts.metatile || this.mml.metatile || 1;
-};
+    render(force) {
+        if (this.xml && !force) return this.xml;
+        this.load(force);
+        var renderer, Renderer;
+        Renderer = this.config.getRenderer(this.config.parsed_opts.renderer);
 
-Project.prototype.getUrl = function () {
-    return '/' + this.id + '/';
-};
+        renderer = new Renderer(this);
+        this.config.log('Generating Mapnik XML…');
+        this.xml = renderer.render();
+        return this.xml;
+    };
 
-Project.prototype.getVectorCacheDir = function () {
-    return path.join(this.cachePath, 'vector');
-};
+    createMapPool(options) {
+        options = options || {};
+        this.render();
+        this.config.log('Loading map…');
+        if (!options.bufferSize) options.bufferSize = this.mml.bufferSize || 256;
+        if(!options.size) options.size = this.metatileSize() * (options.scale || 1);
+        this.mapPool = this.mapnikPool.fromString(this.xml, options, {base: this.root});
+        this.config.log('Map ready');
+        return this.mapPool;
+    };
 
-Project.prototype.getMetaCacheDir = function () {
-    return path.join(this.cachePath, 'meta');
-};
+    export(options, callback) {
+        var format = options.format;
+        if (!this.config.exporters[format]) throw 'Unknown format ' + format;
+        var Exporter = require(this.config.exporters[format]).Exporter;
+        var exporter = new Exporter(this, options);
+        exporter.export(callback);
+    };
 
-Project.prototype.initMetaCache = function (e) {
-    var self = this, cacheFiles = [],
-        dir = this.getMetaCacheDir();
-    Utils.mkdirs(dir, function (err) {
-        if (err) throw err;
-        self.config.log('Creating metatiles cache dir', dir);
-        if (self.config.parsed_opts.keepcache) return e.continue();
-        self.config.log('Deleting previous metatiles', dir);
-        Utils.cleardir(dir, function (err) {
+    toFront() {
+        var options = {
+            center: [this.mml.center[1], this.mml.center[0]],
+            zoom: this.mml.center[2],
+            minZoom: this.mml.minzoom,
+            maxZoom: this.mml.maxzoom,
+            metatile: this.metatile(),
+            name: this.mml.name || '',
+            tileSize: this.tileSize(),
+            loadTime: this.loadTime,
+            layers: this.mml.Layer || []
+        };
+        this.emitAndForward('tofront', {options: options});
+        return options;
+    };
+
+    tileSize() {
+        return 256;
+    };
+
+    metatileSize() {
+        return this.tileSize() * this.metatile();
+    };
+
+    metatile() {
+        return this.config.parsed_opts.metatile || this.mml.metatile || 1;
+    };
+
+    getUrl() {
+        return '/' + this.id + '/';
+    };
+
+    getVectorCacheDir() {
+        return path.join(this.cachePath, 'vector');
+    };
+
+    getMetaCacheDir() {
+        return path.join(this.cachePath, 'meta');
+    };
+
+    initMetaCache(e) {
+        var self = this, cacheFiles = [],
+            dir = this.getMetaCacheDir();
+        Utils.mkdirs(dir, function (err) {
             if (err) throw err;
+            self.config.log('Creating metatiles cache dir', dir);
+            if (self.config.parsed_opts.keepcache) return e.continue();
+            self.config.log('Deleting previous metatiles', dir);
+            Utils.cleardir(dir, function (err) {
+                if (err) throw err;
+                e.continue();
+            });
+        });
+    };
+
+    initVectorCache(e) {
+        var self = this, dir = this.getVectorCacheDir();
+        Utils.mkdirs(dir, function (err) {
+            if (err) throw err;
+            self.config.log('Created vector cache dir', dir);
             e.continue();
         });
-    });
-};
+    };
+}
 
-Project.prototype.initVectorCache = function (e) {
-    var self = this, dir = this.getVectorCacheDir();
-    Utils.mkdirs(dir, function (err) {
-        if (err) throw err;
-        self.config.log('Created vector cache dir', dir);
-        e.continue();
-    });
-};
-
-exports.Project = Project;
+exports = module.exports = { Project };

--- a/src/back/ProjectServer.js
+++ b/src/back/ProjectServer.js
@@ -8,151 +8,81 @@ var fs = require('fs'),
     XRayTile = require('./XRayTile.js').Tile;
 var TILEPREFIX = 'tile';
 
-var ProjectServer = function (project, parent) {
-    this.project = project;
-    this.parent = parent;
-    this._pollQueue = [];
-    var self = this,
-        onChange = function (type, filename) {
-            if (filename) {
-                if (filename.indexOf('.') === 0) return;
-                self.project.config.log('File', filename, 'changed on disk');
-            }
-            self.addToPollQueue({isDirty: true});
-        };
-    this.project.when('loaded', function () {
-        try {
-            self.initMapPools();
-        } catch (err) {
-            console.log(err.message);
-            self.addToPollQueue({error: err.message});
-        }
-        fs.watch(self.project.filepath, onChange);
-        for (var style of self.project.mml.Stylesheet) {
-            fs.watch(path.join(project.root, style.id), onChange);
-        }
-    });
-    this.project.load();
-};
-
-ProjectServer.prototype.serve = function (uri, req, res) {
-    var urlpath = uri.pathname,
-        els = urlpath.split('/'),
-        self = this;
-    if (!urlpath) this.parent.redirect(this.project.getUrl(), res);
-    else if (urlpath === '/') this.main(res);
-    else if (urlpath === '/config/') this.config(res);
-    else if (urlpath === '/poll/') this.poll(res);
-    else if (urlpath === '/export/') this.export(res, uri.query);
-    else if (urlpath === '/reload/') this.reload(res);
-    else if (urlpath === '/clear-vector-cache/') this.clearVectorCache(res);
-    else if (this.parent.hasProjectRoute(urlpath)) this.parent.serveProjectRoute(urlpath, uri, req, res, this.project);
-    else if (els[1] === TILEPREFIX && els.length === 5) this.project.when('loaded', function tile () {self.serveTile(els[2], els[3], els[4], res, uri.query);});
-    else if (els[1] === 'query' && els.length >= 5) this.project.when('loaded', function query () {self.queryTile(els[2], els[3], els[4], res, uri.query);});
-    else this.parent.notFound(urlpath, res);
-};
-
-ProjectServer.prototype.serveTile = function (z, x, y, res, query) {
-    y = y.split('.');
-    var ext = y[1];
-    y = y[0];
-    var func;
-    if (ext === 'json') func = this.jsontile;
-    else if (ext === 'pbf') func = this.pbftile;
-    else if (ext === 'xray') func = this.xraytile;
-    else func = this.tile;
-    try {
-        func.call(this, z, x, y, res, query);
-    } catch (err) {
-        this.raise('Project not loaded properly.', res);
-    }
-};
-
-ProjectServer.prototype.tile = function (z, x, y, res) {
-    var self = this,
-        yels = y.split('@'),
-        y = yels[0],
-        scale = yels[1] ? parseInt(yels[1], 10) : 1,
-        mapScale = scale * (this.project.mml.scale || 1),
-        size = this.project.tileSize() * scale,  // retina?
-        mapPool = scale === 2 ? this.retinaPool : this.mapPool;
-    mapPool.acquire(function (err, map) {
-        var release = function () {mapPool.release(map);};
-        if (err) return self.raise(err.message, res);
-        var tileClass = self.project.mml.source ? VectorBasedTile : self.project.metatile() === 1 ? Tile : MetatileBasedTile;
-        var tile = new tileClass(z, x, y, {size: size, metatile: self.project.metatile(), mapScale: mapScale});
-        return tile.render(self.project, map, function (err, im) {
-            if (err) return self.raise(err.message, res, release);
-            im.encode('png', function (err, buffer) {
-                if (err) return self.raise(err.message, res, release);
-                res.writeHead(200, {'Content-Type': 'image/png', 'Content-Length': buffer.length});
-                res.write(buffer);
-                res.end();
-                release();
-            });
-        });
-    });
-};
-
-ProjectServer.prototype.jsontile = function (z, x, y, res, query) {
-    var self = this;
-    this.vectorMapPool.acquire(function (err, map) {
-        var release = function () {self.vectorMapPool.release(map);};
-        if (err) return self.raise(err.message, res);
-        var tileClass = self.project.mml.source ? VectorBasedTile : Tile;
-        var tile = new tileClass(z, x, y, {metatile: 1});
-        return tile.renderToVector(self.project, map, function (err, tile) {
-            if (err) return self.raise(err.message, res, release);
-            var content;
+class ProjectServer {
+    constructor(project, parent) {
+        this.project = project;
+        this.parent = parent;
+        this._pollQueue = [];
+        var self = this,
+            onChange = function (type, filename) {
+                if (filename) {
+                    if (filename.indexOf('.') === 0) return;
+                    self.project.config.log('File', filename, 'changed on disk');
+                }
+                self.addToPollQueue({isDirty: true});
+            };
+        this.project.when('loaded', function () {
             try {
-                content = tile.toGeoJSON(query.layer || '__all__');
+                self.initMapPools();
             } catch (err) {
-                // This layer is not visible in this tile,
-                // return an empty geojson;
-                content = '{"type": "FeatureCollection", "features": []}';
+                console.log(err.message);
+                self.addToPollQueue({error: err.message});
             }
-            if (typeof content !== 'string') content = JSON.stringify(content);  // Mapnik 3.1.0 now returns a string
-            res.writeHead(200, {'Content-Type': 'application/javascript', 'Access-Control-Allow-Origin': '*'});
-            res.write(content);
-            res.end();
-            release();
+            fs.watch(self.project.filepath, onChange);
+            for (var style of self.project.mml.Stylesheet) {
+                fs.watch(path.join(project.root, style.id), onChange);
+            }
         });
-    });
-};
+        this.project.load();
+    };
 
-ProjectServer.prototype.pbftile = function (z, x, y, res) {
-    var self = this;
-    this.vectorMapPool.acquire(function (err, map) {
-        var release = function () {self.vectorMapPool.release(map);};
-        if (err) return self.raise(err.message, res);
-        var tileClass = self.project.mml.source ? VectorBasedTile : Tile;
+    serve(uri, req, res) {
+        var urlpath = uri.pathname,
+            els = urlpath.split('/'),
+            self = this;
+        if (!urlpath) this.parent.redirect(this.project.getUrl(), res);
+        else if (urlpath === '/') this.main(res);
+        else if (urlpath === '/config/') this.config(res);
+        else if (urlpath === '/poll/') this.poll(res);
+        else if (urlpath === '/export/') this.export(res, uri.query);
+        else if (urlpath === '/reload/') this.reload(res);
+        else if (urlpath === '/clear-vector-cache/') this.clearVectorCache(res);
+        else if (this.parent.hasProjectRoute(urlpath)) this.parent.serveProjectRoute(urlpath, uri, req, res, this.project);
+        else if (els[1] === TILEPREFIX && els.length === 5) this.project.when('loaded', function tile () {self.serveTile(els[2], els[3], els[4], res, uri.query);});
+        else if (els[1] === 'query' && els.length >= 5) this.project.when('loaded', function query () {self.queryTile(els[2], els[3], els[4], res, uri.query);});
+        else this.parent.notFound(urlpath, res);
+    };
+
+    serveTile(z, x, y, res, query) {
+        y = y.split('.');
+        var ext = y[1];
+        y = y[0];
+        var func;
+        if (ext === 'json') func = this.jsontile;
+        else if (ext === 'pbf') func = this.pbftile;
+        else if (ext === 'xray') func = this.xraytile;
+        else func = this.tile;
         try {
-            var tile = new tileClass(z, x, y, {metatile: 1});
+            func.call(this, z, x, y, res, query);
         } catch (err) {
-            return self.raise(err.message, res, release);
+            this.raise('Project not loaded properly.', res);
         }
-        return tile.renderToVector(self.project, map, function (err, tile) {
-            if (err) return self.raise(err.message, res, release);
-            var content = tile.getData();
-            res.writeHead(200, {'Content-Type': 'application/x-protobuf', 'Access-Control-Allow-Origin': '*'});
-            res.write(content);
-            res.end();
-            release();
-        });
-    });
-};
+    };
 
-ProjectServer.prototype.xraytile = function (z, x, y, res, query) {
-    var self = this;
-    this.vectorMapPool.acquire(function (err, map) {
-        var release = function () {self.vectorMapPool.release(map);};
-        if (err) return self.raise(err.message, res, release);
-        var tileClass = self.project.mml.source ? VectorBasedTile : Tile;
-        var tile = new tileClass(z, x, y, {metatile: 1, buffer_size: 1});
-        return tile.renderToVector(self.project, map, function (err, t) {
-            if (err) return self.raise(err.message, res, release);
-            var xtile = new XRayTile(z, x, y, t.getData(), {layer: query.layer, background: query.background});
-            xtile.render(self.project, map, function (err, im) {
+    tile(z, x, y, res) {
+        var self = this,
+            yels = y.split('@'),
+            y = yels[0],
+            scale = yels[1] ? parseInt(yels[1], 10) : 1,
+            mapScale = scale * (this.project.mml.scale || 1),
+            size = this.project.tileSize() * scale,  // retina?
+            mapPool = scale === 2 ? this.retinaPool : this.mapPool;
+        mapPool.acquire(function (err, map) {
+            var release = function () {mapPool.release(map);};
+            if (err) return self.raise(err.message, res);
+            var tileClass = self.project.mml.source ? VectorBasedTile : self.project.metatile() === 1 ? Tile : MetatileBasedTile;
+            var tile = new tileClass(z, x, y, {size: size, metatile: self.project.metatile(), mapScale: mapScale});
+            return tile.render(self.project, map, function (err, im) {
                 if (err) return self.raise(err.message, res, release);
                 im.encode('png', function (err, buffer) {
                     if (err) return self.raise(err.message, res, release);
@@ -163,161 +93,233 @@ ProjectServer.prototype.xraytile = function (z, x, y, res, query) {
                 });
             });
         });
-    });
-};
+    };
 
-ProjectServer.prototype.queryTile = function (z, lat, lon, res, query) {
-    var self = this;
-    lat = parseFloat(lat);
-    lon = parseFloat(lon);
-    this.vectorMapPool.acquire(function (err, map) {
-        var release = function () {self.vectorMapPool.release(map);};
-        var xy = GeoUtils.zoomLatLngToXY(z, lat, lon),
-            x = xy[0], y = xy[1];
-        if (err) return self.raise(err.message, res, release);
-        var tileClass = self.project.mml.source ? VectorBasedTile : Tile;
-        var tile = new tileClass(z, x, y, {metatile: 1});
-        return tile.renderToVector(self.project, map, function (err, t) {
-            if (err) return self.raise(err.message, res, release);
-            var options = {tolerance: parseInt(query.tolerance, 10) || 100};
-            var results = [], layers = [];
-            var doQuery = function (results, options) {
-                var features = t.query(lon, lat, options);
-                for (var i = 0; i < features.length; i++) {
-                    results.push({
-                        distance: features[i].distance,
-                        layer: features[i].layer,
-                        attributes: features[i].attributes()
-                    });
+    jsontile(z, x, y, res, query) {
+        var self = this;
+        this.vectorMapPool.acquire(function (err, map) {
+            var release = function () {self.vectorMapPool.release(map);};
+            if (err) return self.raise(err.message, res);
+            var tileClass = self.project.mml.source ? VectorBasedTile : Tile;
+            var tile = new tileClass(z, x, y, {metatile: 1});
+            return tile.renderToVector(self.project, map, function (err, tile) {
+                if (err) return self.raise(err.message, res, release);
+                var content;
+                try {
+                    content = tile.toGeoJSON(query.layer || '__all__');
+                } catch (err) {
+                    // This layer is not visible in this tile,
+                    // return an empty geojson;
+                    content = '{"type": "FeatureCollection", "features": []}';
                 }
-            };
-            if (query.layer && query.layer !== '__all__') layers = query.layer.split(',');
-            if (!layers.length) {
-                doQuery(results, options);
-            } else {
-                for (var i = 0; i < layers.length; i++) {
-                    options.layer = layers[i];
-                    doQuery(results, options);
-                }
+                if (typeof content !== 'string') content = JSON.stringify(content);  // Mapnik 3.1.0 now returns a string
+                res.writeHead(200, {'Content-Type': 'application/javascript', 'Access-Control-Allow-Origin': '*'});
+                res.write(content);
+                res.end();
+                release();
+            });
+        });
+    };
+
+    pbftile(z, x, y, res) {
+        var self = this;
+        this.vectorMapPool.acquire(function (err, map) {
+            var release = function () {self.vectorMapPool.release(map);};
+            if (err) return self.raise(err.message, res);
+            var tileClass = self.project.mml.source ? VectorBasedTile : Tile;
+            try {
+                var tile = new tileClass(z, x, y, {metatile: 1});
+            } catch (err) {
+                return self.raise(err.message, res, release);
             }
-            res.writeHead(200, {'Content-Type': 'application/javascript'});
-            res.write(JSON.stringify(results));
+            return tile.renderToVector(self.project, map, function (err, tile) {
+                if (err) return self.raise(err.message, res, release);
+                var content = tile.getData();
+                res.writeHead(200, {'Content-Type': 'application/x-protobuf', 'Access-Control-Allow-Origin': '*'});
+                res.write(content);
+                res.end();
+                release();
+            });
+        });
+    };
+
+    xraytile(z, x, y, res, query) {
+        var self = this;
+        this.vectorMapPool.acquire(function (err, map) {
+            var release = function () {self.vectorMapPool.release(map);};
+            if (err) return self.raise(err.message, res, release);
+            var tileClass = self.project.mml.source ? VectorBasedTile : Tile;
+            var tile = new tileClass(z, x, y, {metatile: 1, buffer_size: 1});
+            return tile.renderToVector(self.project, map, function (err, t) {
+                if (err) return self.raise(err.message, res, release);
+                var xtile = new XRayTile(z, x, y, t.getData(), {layer: query.layer, background: query.background});
+                xtile.render(self.project, map, function (err, im) {
+                    if (err) return self.raise(err.message, res, release);
+                    im.encode('png', function (err, buffer) {
+                        if (err) return self.raise(err.message, res, release);
+                        res.writeHead(200, {'Content-Type': 'image/png', 'Content-Length': buffer.length});
+                        res.write(buffer);
+                        res.end();
+                        release();
+                    });
+                });
+            });
+        });
+    };
+
+    queryTile(z, lat, lon, res, query) {
+        var self = this;
+        lat = parseFloat(lat);
+        lon = parseFloat(lon);
+        this.vectorMapPool.acquire(function (err, map) {
+            var release = function () {self.vectorMapPool.release(map);};
+            var xy = GeoUtils.zoomLatLngToXY(z, lat, lon),
+                x = xy[0], y = xy[1];
+            if (err) return self.raise(err.message, res, release);
+            var tileClass = self.project.mml.source ? VectorBasedTile : Tile;
+            var tile = new tileClass(z, x, y, {metatile: 1});
+            return tile.renderToVector(self.project, map, function (err, t) {
+                if (err) return self.raise(err.message, res, release);
+                var options = {tolerance: parseInt(query.tolerance, 10) || 100};
+                var results = [], layers = [];
+                var doQuery = function (results, options) {
+                    var features = t.query(lon, lat, options);
+                    for (var i = 0; i < features.length; i++) {
+                        results.push({
+                            distance: features[i].distance,
+                            layer: features[i].layer,
+                            attributes: features[i].attributes()
+                        });
+                    }
+                };
+                if (query.layer && query.layer !== '__all__') layers = query.layer.split(',');
+                if (!layers.length) {
+                    doQuery(results, options);
+                } else {
+                    for (var i = 0; i < layers.length; i++) {
+                        options.layer = layers[i];
+                        doQuery(results, options);
+                    }
+                }
+                res.writeHead(200, {'Content-Type': 'application/javascript'});
+                res.write(JSON.stringify(results));
+                res.end();
+                release();
+            });
+        });
+    };
+
+    config(res) {
+        res.writeHead(200, {
+            'Content-Type': 'application/javascript'
+        });
+        var tpl = 'L.K.Config.project = %;';
+        res.write(tpl.replace('%', JSON.stringify(this.project.toFront())));
+        res.end();
+    };
+
+    clearVectorCache(res) {
+        var self = this;
+        Utils.cleardir(this.project.getVectorCacheDir(), function (err) {
+            if (err) return self.raise(err.message, res);
+            res.writeHead(204, {
+                'Content-Length': 0,
+                'Content-Type': 'text/html'  // Firefox complains without Content-Type, even if the body is empty.
+            });
             res.end();
-            release();
         });
-    });
-};
+    };
 
-ProjectServer.prototype.config = function (res) {
-    res.writeHead(200, {
-        'Content-Type': 'application/javascript'
-    });
-    var tpl = 'L.K.Config.project = %;';
-    res.write(tpl.replace('%', JSON.stringify(this.project.toFront())));
-    res.end();
-};
-
-ProjectServer.prototype.clearVectorCache = function (res) {
-    var self = this;
-    Utils.cleardir(this.project.getVectorCacheDir(), function (err) {
-        if (err) return self.raise(err.message, res);
-        res.writeHead(204, {
-            'Content-Length': 0,
-            'Content-Type': 'text/html'  // Firefox complains without Content-Type, even if the body is empty.
+    export(res, options) {
+        var self = this;
+        this.project.export(options, function (err, buffer) {
+            if (err) return self.raise(err.message, res);
+            res.writeHead(200, {
+                'Content-Disposition': 'attachment; filename: "xxxx"'
+            });
+            res.write(buffer);
+            res.end();
         });
+    };
+
+    main(res) {
+        var js = this.project.config._js.reduce(function(a, b) {
+            return a + '<script src="' + b + '"></script>\n';
+        }, '');
+        var css = this.project.config._css.reduce(function(a, b) {
+            return a + '<link rel="stylesheet" href="' + b + '" />\n';
+        }, '');
+        fs.readFile(path.join(kosmtik.src, 'front/project.html'), {encoding: 'utf8'}, function(err, data) {
+            if(err) throw err;
+            data = data.replace('%%JS%%', js);
+            data = data.replace('%%CSS%%', css);
+            res.writeHead(200, {
+                'Content-Type': 'text/html',
+                'Content-Length': data.length
+            });
+            res.end(data);
+        });
+    };
+
+    addToPollQueue(message) {
+        if (this._pollQueue.indexOf(message) === -1) this._pollQueue.push(message);
+    };
+
+    raise(message, res, cb) {
+        console.trace();
+        console.log(message);
+        if (message) this.addToPollQueue({error: message});
+        res.writeHead(500);
         res.end();
-    });
-};
+        if (cb) cb();
+    };
 
-ProjectServer.prototype.export = function (res, options) {
-    var self = this;
-    this.project.export(options, function (err, buffer) {
-        if (err) return self.raise(err.message, res);
-        res.writeHead(200, {
-            'Content-Disposition': 'attachment; filename: "xxxx"'
-        });
-        res.write(buffer);
-        res.end();
-    });
-};
-
-ProjectServer.prototype.main = function (res) {
-    var js = this.project.config._js.reduce(function(a, b) {
-        return a + '<script src="' + b + '"></script>\n';
-    }, '');
-    var css = this.project.config._css.reduce(function(a, b) {
-        return a + '<link rel="stylesheet" href="' + b + '" />\n';
-    }, '');
-    fs.readFile(path.join(kosmtik.src, 'front/project.html'), {encoding: 'utf8'}, function(err, data) {
-        if(err) throw err;
-        data = data.replace('%%JS%%', js);
-        data = data.replace('%%CSS%%', css);
-        res.writeHead(200, {
-            'Content-Type': 'text/html',
-            'Content-Length': data.length
+    poll(res) {
+        var data = '', len;
+        if (this._pollQueue.length) {
+            data = JSON.stringify(this._pollQueue);
+            this._pollQueue = [];
+        }
+        len = Buffer.byteLength(data, 'utf8');
+        res.writeHead(len ? 200 : 204, {
+            'Content-Type': 'application/json',
+            'Content-Length': len,
+            'Cache-Control': 'private, no-cache, must-revalidate'
         });
         res.end(data);
-    });
-};
+    };
 
-ProjectServer.prototype.addToPollQueue = function (message) {
-    if (this._pollQueue.indexOf(message) === -1) this._pollQueue.push(message);
-};
-
-ProjectServer.prototype.raise = function (message, res, cb) {
-    console.trace();
-    console.log(message);
-    if (message) this.addToPollQueue({error: message});
-    res.writeHead(500);
-    res.end();
-    if (cb) cb();
-};
-
-ProjectServer.prototype.poll = function (res) {
-    var data = '', len;
-    if (this._pollQueue.length) {
-        data = JSON.stringify(this._pollQueue);
-        this._pollQueue = [];
-    }
-    len = Buffer.byteLength(data, 'utf8');
-    res.writeHead(len ? 200 : 204, {
-        'Content-Type': 'application/json',
-        'Content-Length': len,
-        'Cache-Control': 'private, no-cache, must-revalidate'
-    });
-    res.end(data);
-};
-
-ProjectServer.prototype.reload = function (res) {
-    var self = this;
-    try {
-        this.project.reload();
-    } catch (err) {
-        return this.raise(err.message, res);
-    }
-    this.project.when('loaded', function () {
-        self.mapPool.drain(function() {
-            self.mapPool.destroyAllNow();
-        });
-        self.vectorMapPool.drain(function() {
-            self.vectorMapPool.destroyAllNow();
-        });
+    reload(res) {
+        var self = this;
         try {
-            self.initMapPools();
+            this.project.reload();
         } catch (err) {
-            return self.raise(err.message, res);
+            return this.raise(err.message, res);
         }
-        res.writeHead(200, {
-            'Content-Type': 'application/json'
+        this.project.when('loaded', function () {
+            self.mapPool.drain(function() {
+                self.mapPool.destroyAllNow();
+            });
+            self.vectorMapPool.drain(function() {
+                self.vectorMapPool.destroyAllNow();
+            });
+            try {
+                self.initMapPools();
+            } catch (err) {
+                return self.raise(err.message, res);
+            }
+            res.writeHead(200, {
+                'Content-Type': 'application/json'
+            });
+            res.end(JSON.stringify(self.project.toFront()));
         });
-        res.end(JSON.stringify(self.project.toFront()));
-    });
-};
+    };
 
-ProjectServer.prototype.initMapPools = function () {
-    this.mapPool = this.project.createMapPool();
-    this.retinaPool = this.project.createMapPool({scale: 2});
-    this.vectorMapPool = this.project.createMapPool({size: 256});
-};
+    initMapPools() {
+        this.mapPool = this.project.createMapPool();
+        this.retinaPool = this.project.createMapPool({scale: 2});
+        this.vectorMapPool = this.project.createMapPool({size: 256});
+    };
+}
 
-exports.ProjectServer = ProjectServer;
+exports = module.exports = { ProjectServer };

--- a/src/back/StateBase.js
+++ b/src/back/StateBase.js
@@ -1,64 +1,57 @@
-var util = require('util'),
-    events = require('events');
+var EventEmitter = require('events').EventEmitter;
 
-var StateBase = function () {
-    events.EventEmitter.call(this);
-    this._state_before = {};
-    this._state_to_process = {};
-    this._state_after = {};
-    this._state_done = {};
-};
+class StateBase extends EventEmitter {
+    constructor() {
+        super();
+        this._state_before = {};
+        this._state_to_process = {};
+        this._state_after = {};
+        this._state_done = {};
+    };
 
-util.inherits(StateBase, events.EventEmitter);
+    beforeState (type, listener) {
+        this._state_before[type] = this._state_before[type] || [];
+        this._state_before[type].push(listener);
+    };
 
-
-StateBase.prototype.beforeState = function (type, listener) {
-    this._state_before[type] = this._state_before[type] || [];
-    this._state_before[type].push(listener);
-};
-
-StateBase.prototype.changeState = function (type, e) {
-
-    this._state_done[type] = false;
-    var done = function () {
-        this._state_done[type] = true;
-        if (this._state_after[type]) {
-            for (var i = 0; i < this._state_after[type].length; i++) {
-                this._state_after[type][i]();
+    changeState(type, e) {
+        this._state_done[type] = false;
+        var done = function () {
+            this._state_done[type] = true;
+            if (this._state_after[type]) {
+                for (var i = 0; i < this._state_after[type].length; i++) {
+                    this._state_after[type][i]();
+                }
             }
+            delete this._state_after[type];
+        }.bind(this);
+        e = e || {};
+        e.continue = function () {
+            if(this._state_to_process[type]) {
+                listeners[listeners.length - this._state_to_process[type]--].call(this, e);
+            } else {
+                done();
+            }
+        }.bind(this);
+        e[this.CLASSNAME] = this;
+        var listeners = this._state_before[type] || [],
+            configType = this.CLASSNAME + ':' + type;
+        if (this.config && this.config._state_before[configType]) listeners = listeners.concat(this.config._state_before[configType] || []);
+        if (!this._state_to_process[type]) {
+            this._state_to_process[type] = listeners.length;
+            e.continue();
         }
-        delete this._state_after[type];
-    }.bind(this);
-    e = e || {};
-    e.continue = function () {
-        if(this._state_to_process[type]) {
-            listeners[listeners.length - this._state_to_process[type]--].call(this, e);
-        } else {
-            done();
-        }
-    }.bind(this);
-    e[this.CLASSNAME] = this;
-    var listeners = this._state_before[type] || [],
-        configType = this.CLASSNAME + ':' + type;
-    if (this.config && this.config._state_before[configType]) listeners = listeners.concat(this.config._state_before[configType] || []);
-    if (!this._state_to_process[type]) {
-        this._state_to_process[type] = listeners.length;
-        e.continue();
-    }
-};
+    };
 
-StateBase.prototype.when = function (type, callback) {
-    if (this._state_done[type]) callback();
-    else this.afterState(type, callback);
-};
+    when(type, callback) {
+        if (this._state_done[type]) callback();
+        else this.afterState(type, callback);
+    };
 
-StateBase.prototype.afterState = function (type, callback) {
-    this._state_after[type] = this._state_after[type] || [];
-    this._state_after[type].push(callback);
-};
+    afterState(type, callback) {
+        this._state_after[type] = this._state_after[type] || [];
+        this._state_after[type].push(callback);
+    };
+}
 
-exports.StateBase = StateBase;
-
-
-// config.beforeState('project:loaded', myfunc)
-// project.beforeState('loaded', myfunc)
+exports = module.exports = { StateBase };

--- a/src/back/Tile.js
+++ b/src/back/Tile.js
@@ -1,45 +1,47 @@
 var mapnik = require('mapnik'),
     zoomXYToLatLng = require('./GeoUtils.js').zoomXYToLatLng;
 
-var Tile = function (z, x, y, options) {
-    options = options || {};
-    var DEFAULT_HEIGHT = 256;
-    var DEFAULT_WIDTH = 256;
-    this.z = +z;
-    this.x = +x;
-    this.y = +y;
-    this.projection = new mapnik.Projection(options.projection || Tile.DEFAULT_OUTPUT_PROJECTION);
-    this.scale = options.scale || 1;  // When the tile coverage gets bigger (1024px…) or for metatile.
-    this.mapScale = options.mapScale;  // Retina.
-    this.height = options.height || options.size || DEFAULT_HEIGHT;
-    this.width = options.width || options.size || DEFAULT_WIDTH;
-    this.buffer_size = options.buffer_size || 0;
-};
+class Tile {
+    constructor (z, x, y, options) {
+        options = options || {};
+        var DEFAULT_HEIGHT = 256;
+        var DEFAULT_WIDTH = 256;
+        this.z = +z;
+        this.x = +x;
+        this.y = +y;
+        this.projection = new mapnik.Projection(options.projection || Tile.DEFAULT_OUTPUT_PROJECTION);
+        this.scale = options.scale || 1;  // When the tile coverage gets bigger (1024px…) or for metatile.
+        this.mapScale = options.mapScale;  // Retina.
+        this.height = options.height || options.size || DEFAULT_HEIGHT;
+        this.width = options.width || options.size || DEFAULT_WIDTH;
+        this.buffer_size = options.buffer_size || 0;
+    };
+
+    setupBounds() {
+        var xy = zoomXYToLatLng(this.z, this.x * this.scale, this.y * this.scale);
+        this.maxY = xy[0];
+        this.minX = xy[1];
+        xy = zoomXYToLatLng(this.z, this.x * this.scale + this.scale, this.y * this.scale + this.scale);
+        this.minY = xy[0];
+        this.maxX = xy[1];
+    };
+
+    render(project, map, cb) {
+        this.setupBounds();
+        map.zoomToBox(this.projection.forward([this.minX, this.minY, this.maxX, this.maxY]));
+        var im = new mapnik.Image(this.height, this.width);
+        map.render(im, {scale: this.mapScale || 1, variables: {zoom: this.z}}, cb);
+    };
+
+    renderToVector(project, map, cb) {
+        this.setupBounds();
+        map.zoomToBox(this.projection.forward([this.minX, this.minY, this.maxX, this.maxY]));
+        var surface = new mapnik.VectorTile(this.z, this.x, this.y);
+        map.render(surface, {buffer_size: this.buffer_size}, cb);
+    };
+}
 
 // 900913
 Tile.DEFAULT_OUTPUT_PROJECTION = '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +no_defs +over';
 
-Tile.prototype.setupBounds = function () {
-    var xy = zoomXYToLatLng(this.z, this.x * this.scale, this.y * this.scale);
-    this.maxY = xy[0];
-    this.minX = xy[1];
-    xy = zoomXYToLatLng(this.z, this.x * this.scale + this.scale, this.y * this.scale + this.scale);
-    this.minY = xy[0];
-    this.maxX = xy[1];
-};
-
-Tile.prototype.render = function (project, map, cb) {
-    this.setupBounds();
-    map.zoomToBox(this.projection.forward([this.minX, this.minY, this.maxX, this.maxY]));
-    var im = new mapnik.Image(this.height, this.width);
-    map.render(im, {scale: this.mapScale || 1, variables: {zoom: this.z}}, cb);
-};
-
-Tile.prototype.renderToVector = function (project, map, cb) {
-    this.setupBounds();
-    map.zoomToBox(this.projection.forward([this.minX, this.minY, this.maxX, this.maxY]));
-    var surface = new mapnik.VectorTile(this.z, this.x, this.y);
-    map.render(surface, {buffer_size: this.buffer_size}, cb);
-};
-
-exports.Tile = Tile;
+exports = module.exports = { Tile };

--- a/src/back/Utils.js
+++ b/src/back/Utils.js
@@ -1,64 +1,68 @@
 var fs = require('fs'),
     path = require('path');
 
-module.exports = {
+function mkdirs(dirpath, callback) {
+    fs.mkdir(dirpath, function (err) {
+        if (err && err.code === 'ENOENT') mkdirs(path.dirname(dirpath), function () { mkdirs(dirpath, callback); });
+        else if (err && err.code !== 'EEXIST') callback(err);
+        else callback();
+    });
+}
 
-    mkdirs: function (dirpath, callback) {
-        fs.mkdir(dirpath, function (err) {
-            if (err && err.code === 'ENOENT') module.exports.mkdirs(path.dirname(dirpath), function () {module.exports.mkdirs(dirpath, callback);});
-            else if (err && err.code !== 'EEXIST') callback(err);
-            else callback();
-        });
-    },
-
-    cleardir: function (dirpath, callback) {
-        var files = [], i = 0;
-        try {
-            files = module.exports.tree(dirpath);
-        } catch (err) {
-            if (err && err.code !== 'ENOENT') callback(err);
-        }
-        function loop (err) {
-            if (err) return callback(err);
-            var file = files[i++];
-            if (!file) return callback();
-            if (file.stat.isFile()) fs.unlink(file.path, loop);
-        }
-        loop();
-    },
-
-    sinh: function (x) {
-        var y = Math.exp(x);
-        return (y - 1/y) / 2;
-    },
-
-    template: function (str, data) {
-        return str.replace(/\{ *([\w_]+) *\}/g, function (str, key) {
-            var value = data[key];
-            if (value === undefined) {
-                throw new Error('No value provided for variable ' + str);
-            } else if (typeof value === 'function') {
-                value = value(data);
-            }
-            return value;
-        });
-    },
-
-    tree: function(dir) {
-        var results = [];
-        var list = fs.readdirSync(dir);
-        list.forEach(function(file) {
-            file = path.join(dir, file);
-            try {
-                var stat = fs.statSync(file);
-            } catch (e) {
-                // Dead link?
-                return;
-            }
-            results.push({path: file, stat: stat});
-            if (stat && stat.isDirectory()) results = results.concat(module.exports.tree(file));
-        });
-        return results;
+function cleardir(dirpath, callback) {
+    var files = [], i = 0;
+    try {
+        files = tree(dirpath);
+    } catch (err) {
+        if (err && err.code !== 'ENOENT') callback(err);
     }
+    function loop(err) {
+        if (err) return callback(err);
+        var file = files[i++];
+        if (!file) return callback();
+        if (file.stat.isFile()) fs.unlink(file.path, loop);
+    }
+    loop();
+}
 
+function sinh(x) {
+    var y = Math.exp(x);
+    return (y - 1 / y) / 2;
+}
+
+function template(str, data) {
+    return str.replace(/\{ *([\w_]+) *\}/g, function (str, key) {
+        var value = data[key];
+        if (value === undefined) {
+            throw new Error('No value provided for variable ' + str);
+        } else if (typeof value === 'function') {
+            value = value(data);
+        }
+        return value;
+    });
+}
+
+function tree(dir) {
+    var results = [];
+    var list = fs.readdirSync(dir);
+    list.forEach(function (file) {
+        file = path.join(dir, file);
+        try {
+            var stat = fs.statSync(file);
+        } catch (e) {
+            // Dead link?
+            return;
+        }
+        results.push({ path: file, stat: stat });
+        if (stat && stat.isDirectory()) results = results.concat(tree(file));
+    });
+    return results;
+}
+
+exports = module.exports = {
+    mkdirs,
+    cleardir,
+    sinh,
+    template,
+    tree
 };

--- a/src/back/VectorBasedTile.js
+++ b/src/back/VectorBasedTile.js
@@ -1,124 +1,122 @@
-var util = require('util'),
-    mapnik = require('mapnik'),
+var mapnik = require('mapnik'),
     path = require('path'),
     fs = require('fs'),
     Tile = require('./Tile.js').Tile,
     Utils = require('./Utils.js'),
     zlib = require('zlib');
 
-var VectorBasedTile = function (z, x, y, options) {
-    Tile.call(this, z, x, y, options);
-};
-
-util.inherits(VectorBasedTile, Tile);
-
-VectorBasedTile.prototype._render = function (project, map, cb) {
-    this.setupBounds();
-    map.zoomToBox(this.projection.forward([this.minX, this.minY, this.maxX, this.maxY]));
-
-    //Support for overzooming
-    var params = {
-        z: this.z,
-        x: this.x,
-        y: this.y
+class VectorBasedTile extends Tile {
+    constructor(z, x, y, options) {
+        Tile.call(this, z, x, y, options);
     };
-    while(params.z > project.mml.sourceMaxzoom) {
-        params = {
-            z: params.z - 1,
-            x: Math.floor(params.x/2),
-            y: Math.floor(params.y/2)
-        };
-    }
 
-    var vtile = new mapnik.VectorTile(params.z, params.x, params.y),
-        processed = 0,
-        parse = function (err, data) {
-            if (err) return cb(err);
-            function done () {
-                if (++processed === project.mml.source.length) cb(null, vtile);
-            }
-            if (!data.length) return done();
-            vtile.setData(data, function(err) {
-                if(err) {
-                    console.log(err.message);
-                    return cb(new Error('Unable to parse vector tile data for uri ' + resp.request.uri.href));
-                }
-                done();
-            });
-        };
+    _render(project, map, cb) {
+        this.setupBounds();
+        map.zoomToBox(this.projection.forward([this.minX, this.minY, this.maxX, this.maxY]));
 
-    for (var i = 0; i < project.mml.source.length; i++) {
-        var options = {
-            uri: Utils.template(project.mml.source[i].url, params),
-            encoding: null  // we want a buffer, not a string
-        };
-        this.load(project, options, parse);
-    }
-};
-
-VectorBasedTile.prototype.fetch = function (project, options, cb) {
-    var self = this,
-        onResponse = function (err, resp, body) {
-            if (err) return cb(err);
-            if (resp.statusCode !== 200) return cb(new Error('Unable to retrieve data from ' + resp.request.uri.href));
-            var compression = false;
-            if (resp.headers['content-encoding'] === 'gzip') compression = 'gunzip';
-            else if (resp.headers['content-encoding'] === 'deflate') compression = 'inflate';
-            else if (body && body[0] === 0x1F && body[1] === 0x8B) compression = 'gunzip';
-            else if (body && body[0] === 0x78 && body[1] === 0x9C) compression = 'inflate';
-            if (compression) {
-                zlib[compression](body, function(err, data) {
-                    if (err) return cb(err);
-                    cb(null, data);
-                });
-            } else {
-                cb(null, body);
-            }
-        };
-    project.config.helpers.request(options, onResponse);
-};
-
-VectorBasedTile.prototype.load = function (project, options, cb) {
-    if (project.config.userConfig.cacheVectorTiles === false) return this.fetch(project, options, cb);
-    var self = this,
-        cachedir = project.getVectorCacheDir(),
-        filepath = path.join(cachedir, options.uri.replace(/\//g, '.') + '.cache'),
-        write = function (err, data) {
-            if (err) return cb(err);
-            fs.writeFile(filepath, data, function (err) {
-                if (err) cb(err);
-                else cb(null, data);
-            });
-        };
-    fs.readFile(filepath, function (err, data) {
-        if (err) {
-            if (err.code !== 'ENOENT') return cb(err);
-            self.fetch(project, options, write);
-            return;
-        }
-        cb(null, data);
-    });
-};
-
-
-VectorBasedTile.prototype.render = function (project, map, cb) {
-    var self = this,
-        opts = {
-            buffer_size: map.bufferSize,
+        //Support for overzooming
+        var params = {
             z: this.z,
             x: this.x,
             y: this.y
         };
-    this._render(project, map, function (err, vtile) {
-        if (err) cb(err);
-        else vtile.render(map, new mapnik.Image(self.width, self.height), opts, cb);
-    });
-};
+        while(params.z > project.mml.sourceMaxzoom) {
+            params = {
+                z: params.z - 1,
+                x: Math.floor(params.x/2),
+                y: Math.floor(params.y/2)
+            };
+        }
+
+        var vtile = new mapnik.VectorTile(params.z, params.x, params.y),
+            processed = 0,
+            parse = function (err, data) {
+                if (err) return cb(err);
+                function done () {
+                    if (++processed === project.mml.source.length) cb(null, vtile);
+                }
+                if (!data.length) return done();
+                vtile.setData(data, function(err) {
+                    if(err) {
+                        console.log(err.message);
+                        return cb(new Error('Unable to parse vector tile data for uri ' + resp.request.uri.href));
+                    }
+                    done();
+                });
+            };
+
+        for (var i = 0; i < project.mml.source.length; i++) {
+            var options = {
+                uri: Utils.template(project.mml.source[i].url, params),
+                encoding: null  // we want a buffer, not a string
+            };
+            this.load(project, options, parse);
+        }
+    };
+
+    fetch(project, options, cb) {
+        var self = this,
+            onResponse = function (err, resp, body) {
+                if (err) return cb(err);
+                if (resp.statusCode !== 200) return cb(new Error('Unable to retrieve data from ' + resp.request.uri.href));
+                var compression = false;
+                if (resp.headers['content-encoding'] === 'gzip') compression = 'gunzip';
+                else if (resp.headers['content-encoding'] === 'deflate') compression = 'inflate';
+                else if (body && body[0] === 0x1F && body[1] === 0x8B) compression = 'gunzip';
+                else if (body && body[0] === 0x78 && body[1] === 0x9C) compression = 'inflate';
+                if (compression) {
+                    zlib[compression](body, function(err, data) {
+                        if (err) return cb(err);
+                        cb(null, data);
+                    });
+                } else {
+                    cb(null, body);
+                }
+            };
+        project.config.helpers.request(options, onResponse);
+    };
+
+    load(project, options, cb) {
+        if (project.config.userConfig.cacheVectorTiles === false) return this.fetch(project, options, cb);
+        var self = this,
+            cachedir = project.getVectorCacheDir(),
+            filepath = path.join(cachedir, options.uri.replace(/\//g, '.') + '.cache'),
+            write = function (err, data) {
+                if (err) return cb(err);
+                fs.writeFile(filepath, data, function (err) {
+                    if (err) cb(err);
+                    else cb(null, data);
+                });
+            };
+        fs.readFile(filepath, function (err, data) {
+            if (err) {
+                if (err.code !== 'ENOENT') return cb(err);
+                self.fetch(project, options, write);
+                return;
+            }
+            cb(null, data);
+        });
+    };
 
 
-VectorBasedTile.prototype.renderToVector = function (project, map, cb) {
-    this._render(project, map, cb);
-};
+    render(project, map, cb) {
+        var self = this,
+            opts = {
+                buffer_size: map.bufferSize,
+                z: this.z,
+                x: this.x,
+                y: this.y
+            };
+        this._render(project, map, function (err, vtile) {
+            if (err) cb(err);
+            else vtile.render(map, new mapnik.Image(self.width, self.height), opts, cb);
+        });
+    };
 
 
-exports.Tile = VectorBasedTile;
+    renderToVector(project, map, cb) {
+        this._render(project, map, cb);
+    };
+}
+
+exports = module.exports = { Tile: VectorBasedTile };

--- a/src/back/XRayTile.js
+++ b/src/back/XRayTile.js
@@ -4,47 +4,49 @@ var mapnik = require('mapnik'),
     path = require('path'),
     crypto = require('crypto');
 
-var XRayTile = function (z, x, y, data, options) {
-    this.z = +z;
-    this.x = +x;
-    this.y = +y;
-    this.data = data;
-    this.options = options || {};
-};
+class XRayTile {
+    constructor(z, x, y, data, options) {
+        this.z = +z;
+        this.x = +x;
+        this.y = +y;
+        this.data = data;
+        this.options = options || {};
+    };
 
-XRayTile.prototype.render = function (project, map, cb) {
-    var styleMap = this.styleMap(project),
-        vtile = new mapnik.VectorTile(this.z, this.x, this.y);
-    if (this.data.length){
-        vtile.setData(this.data, function(err) {
-            if(err) {
-                console.log(err.message);
-                return cb(err);
-            }
-            vtile.render(styleMap, new mapnik.Image(256, 256), cb);  
-        });
-    }
-};
+    render(project, map, cb) {
+        var styleMap = this.styleMap(project),
+            vtile = new mapnik.VectorTile(this.z, this.x, this.y);
+        if (this.data.length){
+            vtile.setData(this.data, function(err) {
+                if(err) {
+                    console.log(err.message);
+                    return cb(err);
+                }
+                vtile.render(styleMap, new mapnik.Image(256, 256), cb);  
+            });
+        }
+    };
 
-XRayTile.prototype.styleMap = function (project) {
-    var self = this,
-        map = new mapnik.Map(256, 256),
-        idx = 0,
-        chosenLayers = (self.options.layer) ? self.options.layer.split(',') : [],
-        layers = project.mml.Layer.reduce(function (prev, layer) {
-            if (chosenLayers.length && chosenLayers.indexOf(layer.id) === -1) return prev;
-            if (idx >= XRayTile.colors.length) idx = 0;
-            return prev + Utils.template(XRayTile.layerTemplate, {id: layer.id, rgb: XRayTile.colors[idx++]});
-        }, ''),
-        xml = Utils.template(XRayTile.mapTemplate, {layers: layers || '', bg: this.options.background || '#000000'});
-    map.fromStringSync(xml);
-    return map;
-};
+    styleMap(project) {
+        var self = this,
+            map = new mapnik.Map(256, 256),
+            idx = 0,
+            chosenLayers = (self.options.layer) ? self.options.layer.split(',') : [],
+            layers = project.mml.Layer.reduce(function (prev, layer) {
+                if (chosenLayers.length && chosenLayers.indexOf(layer.id) === -1) return prev;
+                if (idx >= XRayTile.colors.length) idx = 0;
+                return prev + Utils.template(XRayTile.layerTemplate, {id: layer.id, rgb: XRayTile.colors[idx++]});
+            }, ''),
+            xml = Utils.template(XRayTile.mapTemplate, {layers: layers || '', bg: this.options.background || '#000000'});
+        map.fromStringSync(xml);
+        return map;
+    };
 
-XRayTile.prototype.stringToRGB = function (s) {
-    var hash = crypto.createHash('md5').update(s).digest('hex').slice(0, 3);
-    return [hash.charCodeAt(0) + 100, hash.charCodeAt(1) + 100, hash.charCodeAt(2) + 100].join(',');
-};
+    stringToRGB(s) {
+        var hash = crypto.createHash('md5').update(s).digest('hex').slice(0, 3);
+        return [hash.charCodeAt(0) + 100, hash.charCodeAt(1) + 100, hash.charCodeAt(2) + 100].join(',');
+    };
+}
 
 XRayTile.mapTemplate = fs.readFileSync(path.join(__dirname, 'xray', 'map.xml'), 'utf8');
 XRayTile.layerTemplate = fs.readFileSync(path.join(__dirname, 'xray', 'layer.xml'), 'utf8');
@@ -52,5 +54,4 @@ XRayTile.colors = [
     '218,223,225', '217,30,24', '102,51,153', '68,108,179', '247,202,24', '38,166,91', '78,205,196', '219,10,91', '232,126,4', '135,211,124'
 ];
 
-
-exports.Tile = XRayTile;
+exports = module.exports = { Tile: XRayTile };

--- a/src/back/loader/Base.js
+++ b/src/back/loader/Base.js
@@ -2,81 +2,83 @@ var fs = require('fs'),
     path = require('path'),
     url = require('url');
 
-var BaseLoader = function (project) {
-    this.project = project;
-};
+class BaseLoader {
+    constructor(project) {
+        this.project = project;
+    }
 
-BaseLoader.prototype.postprocess = function () {
-    this.mml.metatile = +(this.mml.metatile || (this.mml.source ? 1 : 2));  // Default vectortiles to 1, classic to 2.
-    if (this.mml.Stylesheet) {
-        this.mml.Stylesheet = this.mml.Stylesheet.map(this.normalizeStylesheet.bind(this));
-    }
-    if (this.mml.styles) {
-        this.mml.Stylesheet = (this.mml.Stylesheet || []).concat(this.mml.styles.map(this.normalizeStylesheet.bind(this)));
-    }
-    if (!this.mml.Layer) this.mml.Layer = [];
-    if (this.mml.layers) {
-        this.mml.Layer = (this.mml.Layer || []).concat(this.mml.layers.map(this.expandLayerName.bind(this)));
-    }
-    this.mml.Layer = this.mml.Layer.map(this.normalizeLayer);
-    if (this.mml.source) {
-        if (typeof this.mml.source === 'string') this.mml.source = this.mml.source.split(this.mml.source_separator || ',');
-        this.mml.source = this.mml.source.map(this.normalizeSource);
-    }
-    // Do not hardcode me, hombre!
-    if (!this.mml.srs) this.mml.srs = '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over';
-};
-
-BaseLoader.prototype.normalizeLayer = function (layer) {
-    if (!layer.srs) layer.srs = this.srs;
-    return layer;
-};
-
-BaseLoader.prototype.normalizeSource = function (source) {
-    if (typeof source === 'string') {
-        var uri = url.parse(source);
-        // Since 0.12, url.parse escapes unwise chars in URL, but we need
-        // to keep the variables, like {x}, {y} as is.
-        uri.href = uri.href.replace(/%7B/g, '{').replace(/%7D/g, '}');
-        source = {
-            protocol: uri.protocol
-        };
-        if (source.protocol === 'tmsource:') {
-            // Relative path badly parsed by Node.
-            if (uri.host === '..' || uri.host === '.') source.path = uri.host + uri.path;
-            else source.path = uri.path;
-        } else if (source.protocol.indexOf('http') === 0) {
-            source.tilejson = uri.href;
-        } else if (source.protocol.indexOf('tms') === 0) {
-            source.url = uri.href.replace(/^tms/, 'http');
-        } else {
-            source.url = uri.href;
+    postprocess() {
+        this.mml.metatile = +(this.mml.metatile || (this.mml.source ? 1 : 2));  // Default vectortiles to 1, classic to 2.
+        if (this.mml.Stylesheet) {
+            this.mml.Stylesheet = this.mml.Stylesheet.map(this.normalizeStylesheet.bind(this));
         }
-    }
-    return source;
-};
+        if (this.mml.styles) {
+            this.mml.Stylesheet = (this.mml.Stylesheet || []).concat(this.mml.styles.map(this.normalizeStylesheet.bind(this)));
+        }
+        if (!this.mml.Layer) this.mml.Layer = [];
+        if (this.mml.layers) {
+            this.mml.Layer = (this.mml.Layer || []).concat(this.mml.layers.map(this.expandLayerName.bind(this)));
+        }
+        this.mml.Layer = this.mml.Layer.map(this.normalizeLayer);
+        if (this.mml.source) {
+            if (typeof this.mml.source === 'string') this.mml.source = this.mml.source.split(this.mml.source_separator || ',');
+            this.mml.source = this.mml.source.map(this.normalizeSource);
+        }
+        // Do not hardcode me, hombre!
+        if (!this.mml.srs) this.mml.srs = '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over';
+    };
 
-BaseLoader.prototype.expandLayerName = function (name) {
-    var className = '';
-    if (name.indexOf('.') !== -1) {
-        var els = name.split('.');
-        name = els[0];
-        className = els[1];
-    }
-    return {id: name, 'class': className};
-};
+    normalizeLayer(layer) {
+        if (!layer.srs) layer.srs = this.srs;
+        return layer;
+    };
 
-BaseLoader.prototype.normalizeStylesheet = function (style) {
-    if (typeof style !== 'string') {
-        return { id: style.id, data: style.data };
-    }
-    return { id: style, data: fs.readFileSync(path.join(this.project.root, style), 'utf8') };
-};
+    normalizeSource(source) {
+        if (typeof source === 'string') {
+            var uri = url.parse(source);
+            // Since 0.12, url.parse escapes unwise chars in URL, but we need
+            // to keep the variables, like {x}, {y} as is.
+            uri.href = uri.href.replace(/%7B/g, '{').replace(/%7D/g, '}');
+            source = {
+                protocol: uri.protocol
+            };
+            if (source.protocol === 'tmsource:') {
+                // Relative path badly parsed by Node.
+                if (uri.host === '..' || uri.host === '.') source.path = uri.host + uri.path;
+                else source.path = uri.path;
+            } else if (source.protocol.indexOf('http') === 0) {
+                source.tilejson = uri.href;
+            } else if (source.protocol.indexOf('tms') === 0) {
+                source.url = uri.href.replace(/^tms/, 'http');
+            } else {
+                source.url = uri.href;
+            }
+        }
+        return source;
+    };
 
-BaseLoader.prototype.load = function () {
-    this.mml = this.loadFile();
-    this.postprocess();
-    return this.mml;
-};
+    expandLayerName(name) {
+        var className = '';
+        if (name.indexOf('.') !== -1) {
+            var els = name.split('.');
+            name = els[0];
+            className = els[1];
+        }
+        return {id: name, 'class': className};
+    };
 
-exports.BaseLoader = BaseLoader;
+    normalizeStylesheet(style) {
+        if (typeof style !== 'string') {
+            return { id: style.id, data: style.data };
+        }
+        return { id: style, data: fs.readFileSync(path.join(this.project.root, style), 'utf8') };
+    };
+
+    load() {
+        this.mml = this.loadFile();
+        this.postprocess();
+        return this.mml;
+    };
+}
+
+exports = module.exports = { BaseLoader };

--- a/src/back/loader/MML.js
+++ b/src/back/loader/MML.js
@@ -1,15 +1,11 @@
 var fs = require('fs'),
-    util = require('util'),
     yaml = require('js-yaml'),
     BaseLoader = require('./Base.js').BaseLoader;
 
-var Loader = function (project) {
-    BaseLoader.call(this, project);
-};
-util.inherits(Loader, BaseLoader);
+class Loader extends BaseLoader {
+    loadFile() {
+        return yaml.safeLoad(fs.readFileSync(this.project.filepath, 'utf8'));
+    };
+}
 
-Loader.prototype.loadFile = function () {
-    return yaml.safeLoad(fs.readFileSync(this.project.filepath, 'utf8'));
-};
-
-exports.Loader = Loader;
+exports = module.exports = { Loader};

--- a/src/back/renderer/Carto.js
+++ b/src/back/renderer/Carto.js
@@ -1,36 +1,37 @@
 var carto = require('carto');
 
-
-var Carto = function (project) {
-    this.project = project;
-};
-
-Carto.prototype.render = function () {
-    var env = {
-            filename: this.project.filepath,
-            local_data_dir: this.project.root,
-            validation_data: { fonts: this.project.mapnik.fonts() },
-            returnErrors: true,
-            effects: []
-        },
-        options = {
-            mapnik_version: this.project.mml.mapnik_version || this.project.config.parsed_opts.mapnik_version
-        };
-    this.project.config.log('Using mapnik version', options.mapnik_version);
-    var output = new carto.Renderer(env, options).render(this.project.mml);
-
-    if (output.msg) {
-        output.msg.forEach(function (v) {
-            if (v.type === 'error') {
-                console.error(carto.Util.getMessageToPrint(v));
-            }
-            else if (v.type === 'warning') {
-                console.warn(carto.Util.getMessageToPrint(v));
-            }
-        });
+class Carto {
+    constructor(project) {
+        this.project = project;
     }
 
-    return output.data;
+    render() {
+        var env = {
+                filename: this.project.filepath,
+                local_data_dir: this.project.root,
+                validation_data: { fonts: this.project.mapnik.fonts() },
+                returnErrors: true,
+                effects: []
+            },
+            options = {
+                mapnik_version: this.project.mml.mapnik_version || this.project.config.parsed_opts.mapnik_version
+            };
+        this.project.config.log('Using mapnik version', options.mapnik_version);
+        var output = new carto.Renderer(env, options).render(this.project.mml);
+    
+        if (output.msg) {
+            output.msg.forEach(function (v) {
+                if (v.type === 'error') {
+                    console.error(carto.Util.getMessageToPrint(v));
+                }
+                else if (v.type === 'warning') {
+                    console.warn(carto.Util.getMessageToPrint(v));
+                }
+            });
+        }
+    
+        return output.data;
+    };
 };
 
-exports.Renderer = Carto;
+exports = module.exports = { Renderer: Carto };

--- a/src/plugins/base-exporters/Base.js
+++ b/src/plugins/base-exporters/Base.js
@@ -1,10 +1,12 @@
-var BaseExporter = function (project, options) {
-    this.project = project;
-    this.options = options;
-};
+class BaseExporter {
+    constructor(project, options) {
+        this.project = project;
+        this.options = options;
+    };
 
-BaseExporter.prototype.log = function () {
-    console.warn.apply(console, Array.prototype.concat.apply(['[Export]'], arguments));
-};
+    log() {
+        console.warn.apply(console, Array.prototype.concat.apply(['[Export]'], arguments));
+    };
+}
 
-exports.BaseExporter = BaseExporter;
+exports = module.exports = { BaseExporter };

--- a/src/plugins/base-exporters/MML.js
+++ b/src/plugins/base-exporters/MML.js
@@ -1,14 +1,9 @@
-var util = require('util'),
-    BaseExporter = require('./Base.js').BaseExporter;
+var BaseExporter = require('./Base.js').BaseExporter;
 
-var MMLExporter = function (project, options) {
-    BaseExporter.call(this, project, options);
-};
+class MMLExporter extends BaseExporter {
+    export(callback) {
+        callback(null, JSON.stringify(this.project.load(), null, 4));
+    };
+}
 
-util.inherits(MMLExporter, BaseExporter);
-
-MMLExporter.prototype.export = function (callback) {
-    callback(null, JSON.stringify(this.project.load(), null, 4));
-};
-
-exports.Exporter = MMLExporter;
+exports = module.exports = { Exporter: MMLExporter };

--- a/src/plugins/base-exporters/PNG.js
+++ b/src/plugins/base-exporters/PNG.js
@@ -1,66 +1,62 @@
-var util = require('util'),
-    mapnik = require('mapnik'),
+var mapnik = require('mapnik'),
     GeoUtils = require('../../back/GeoUtils.js'),
     VectorBasedTile = require('../../back/VectorBasedTile.js').Tile,
     BaseExporter = require('./Base.js').BaseExporter;
 
-var PNGExporter = function (project, options) {
-    BaseExporter.call(this, project, options);
-};
+class PNGExporter extends BaseExporter {
 
-util.inherits(PNGExporter, BaseExporter);
-
-PNGExporter.prototype.export = function (callback) {
-    this.scale = this.options.scale ? +this.options.scale : 2;
-    if (this.options.bounds) this.bounds = this.options.bounds.split(',').map(function (x) {return +x;});
-    else this.bounds = this.project.mml.bounds;
-    if (this.project.mml.source) this.renderFromVector(callback);
-    else this.render(callback);
-};
-PNGExporter.prototype.render = function (callback) {
-    var self = this;
-    var map = new mapnik.Map(+this.options.width, +this.options.height);
-    map.fromString(this.project.render(), {base: this.project.root}, function render (err, map) {
-        var projection = new mapnik.Projection(map.srs),
-            im = new mapnik.Image(+self.options.width, +self.options.height);
-        map.zoomToBox(projection.forward(self.bounds));
-        map.render(im, {scale: self.scale}, function toImage (err, im) {
-            if (err) throw err;
-            im.encode(self.options.format, callback);
-        });
-    });
-};
-
-PNGExporter.prototype.renderFromVector = function (callback) {
-    var self = this,
-        leftTop = GeoUtils.zoomLatLngToXY(this.options.zoom, this.bounds[3], this.bounds[0]),
-        rightBottom = GeoUtils.zoomLatLngToXY(this.options.zoom, this.bounds[1], this.bounds[2]),
-        floatLeftTop = GeoUtils.zoomLatLngToFloatXY(this.options.zoom, this.bounds[3], this.bounds[0]),
-        size = self.project.tileSize() * this.scale,
-        gap = [(floatLeftTop[0] - leftTop[0]) * size, (floatLeftTop[1] - leftTop[1]) * size],
-        map = new mapnik.Map(+this.options.width, +this.options.height),
-        data = [], processed = 0, toProcess = [],
-        commit = function () {
-            mapnik.blend(data, {format: 'png', width: +self.options.width, height: +self.options.height}, callback);
-        };
-    map.fromStringSync(this.project.render(), {base: this.project.root});
-    var processTile = function (x, y) {
-        var tile = new VectorBasedTile(self.options.zoom, x, y, {width: size, height: size});
-        return tile.render(self.project, map, function (err, im) {
-            if (err) throw err;
-            im.encode('png', function (err, buffer) {
-                data.push({buffer: buffer, x: (x - leftTop[0]) * size - gap[0], y: (y - leftTop[1]) * size - gap[1]});
-                if (toProcess[++processed]) processTile.apply(this, toProcess[processed]);
-                else commit();
+    export(callback) {
+        this.scale = this.options.scale ? +this.options.scale : 2;
+        if (this.options.bounds) this.bounds = this.options.bounds.split(',').map(function (x) {return +x;});
+        else this.bounds = this.project.mml.bounds;
+        if (this.project.mml.source) this.renderFromVector(callback);
+        else this.render(callback);
+    };
+    render(callback) {
+        var self = this;
+        var map = new mapnik.Map(+this.options.width, +this.options.height);
+        map.fromString(this.project.render(), {base: this.project.root}, function render (err, map) {
+            var projection = new mapnik.Projection(map.srs),
+                im = new mapnik.Image(+self.options.width, +self.options.height);
+            map.zoomToBox(projection.forward(self.bounds));
+            map.render(im, {scale: self.scale}, function toImage (err, im) {
+                if (err) throw err;
+                im.encode(self.options.format, callback);
             });
         });
     };
-    for (var x = leftTop[0]; x <= rightBottom[0]; x++) {
-        for (var y = leftTop[1]; y <= rightBottom[1]; y++) {
-            toProcess.push([x, y]);
-        }
-    }
-    processTile.apply(this, toProcess[processed]);
-};
 
-exports.Exporter = PNGExporter;
+    renderFromVector(callback) {
+        var self = this,
+            leftTop = GeoUtils.zoomLatLngToXY(this.options.zoom, this.bounds[3], this.bounds[0]),
+            rightBottom = GeoUtils.zoomLatLngToXY(this.options.zoom, this.bounds[1], this.bounds[2]),
+            floatLeftTop = GeoUtils.zoomLatLngToFloatXY(this.options.zoom, this.bounds[3], this.bounds[0]),
+            size = self.project.tileSize() * this.scale,
+            gap = [(floatLeftTop[0] - leftTop[0]) * size, (floatLeftTop[1] - leftTop[1]) * size],
+            map = new mapnik.Map(+this.options.width, +this.options.height),
+            data = [], processed = 0, toProcess = [],
+            commit = function () {
+                mapnik.blend(data, {format: 'png', width: +self.options.width, height: +self.options.height}, callback);
+            };
+        map.fromStringSync(this.project.render(), {base: this.project.root});
+        var processTile = function (x, y) {
+            var tile = new VectorBasedTile(self.options.zoom, x, y, {width: size, height: size});
+            return tile.render(self.project, map, function (err, im) {
+                if (err) throw err;
+                im.encode('png', function (err, buffer) {
+                    data.push({buffer: buffer, x: (x - leftTop[0]) * size - gap[0], y: (y - leftTop[1]) * size - gap[1]});
+                    if (toProcess[++processed]) processTile.apply(this, toProcess[processed]);
+                    else commit();
+                });
+            });
+        };
+        for (var x = leftTop[0]; x <= rightBottom[0]; x++) {
+            for (var y = leftTop[1]; y <= rightBottom[1]; y++) {
+                toProcess.push([x, y]);
+            }
+        }
+        processTile.apply(this, toProcess[processed]);
+    };
+}
+
+exports = module.exports = { Exporter: PNGExporter};

--- a/src/plugins/base-exporters/XML.js
+++ b/src/plugins/base-exporters/XML.js
@@ -1,14 +1,9 @@
-var util = require('util'),
-    BaseExporter = require('./Base.js').BaseExporter;
+var BaseExporter = require('./Base.js').BaseExporter;
 
-var XMLExporter = function (project, options) {
-    BaseExporter.call(this, project, options);
-};
+class XMLExporter extends BaseExporter {
+    export(callback) {
+        callback(null, this.project.render());
+    };
+}
 
-util.inherits(XMLExporter, BaseExporter);
-
-XMLExporter.prototype.export = function (callback) {
-    callback(null, this.project.render());
-};
-
-exports.Exporter = XMLExporter;
+exports = module.exports = { Exporter: XMLExporter};

--- a/src/plugins/base-exporters/YAML.js
+++ b/src/plugins/base-exporters/YAML.js
@@ -1,15 +1,10 @@
-var util = require('util'),
-    BaseExporter = require('./Base.js').BaseExporter,
+var BaseExporter = require('./Base.js').BaseExporter,
     yaml = require('js-yaml');
 
-var YAMLExporter = function (project, options) {
-    BaseExporter.call(this, project, options);
-};
+class YAMLExporter extends BaseExporter {
+    export(callback) {
+        callback(null, yaml.safeDump(this.project.load()));
+    };
+}
 
-util.inherits(YAMLExporter, BaseExporter);
-
-YAMLExporter.prototype.export = function (callback) {
-    callback(null, yaml.safeDump(this.project.load()));
-};
-
-exports.Exporter = YAMLExporter;
+exports = module.exports = { Exporter: YAMLExporter };

--- a/src/plugins/base-exporters/index.js
+++ b/src/plugins/base-exporters/index.js
@@ -1,81 +1,83 @@
 var fs = require('fs'),
     path = require('path');
 
-var BaseExporters = function (config) {
-    config.commands.export = config.opts.command('export').help('Export a project');
-    config.commands.export.option('project', {
-        position: 1,
-        help: 'Project to export.'
-    });
-    config.commands.export.option('output', {
-        help: 'Filepath to save in',
-        metavar: 'PATH'
-    });
-    config.commands.export.option('width', {
-        help: 'Width of the export',
-        metavar: 'INT',
-        default: 1000
-    });
-    config.commands.export.option('height', {
-        help: 'Height of the export',
-        metavar: 'INT',
-        default: 1000
-    });
-    config.commands.export.option('bounds', {
-        help: 'BBox to use [Default: project extent]',
-        metavar: 'minX,minY,maxX,maxY'
-    });
-    config.commands.export.option('scale', {
-        help: 'Scale the exported image',
-        metavar: 'INT',
-        default: 1
-    });
-    config.on('command:export', this.handleCommand);
-    config.registerExporter('xml', path.join(__dirname, 'XML.js'));
-    config.registerExporter('mml', path.join(__dirname, 'MML.js'));
-    config.registerExporter('yml', path.join(__dirname, 'YAML.js'));
-    config.registerExporter('yaml', path.join(__dirname, 'YAML.js'));
-    config.registerExporter('png', path.join(__dirname, 'PNG.js'));
-    config.registerExporter('png8', path.join(__dirname, 'PNG.js'));
-    config.registerExporter('png24', path.join(__dirname, 'PNG.js'));
-    config.registerExporter('png32', path.join(__dirname, 'PNG.js'));
-    config.registerExporter('png256', path.join(__dirname, 'PNG.js'));
-    config.on('parseopts', this.parseOpts);
-    config.addJS('/src/plugins/base-exporters/front/export.js');
-};
-
-BaseExporters.prototype.parseOpts = function (e) {
-    this.commands.export.option('format', {
-        help: 'Format of the export',
-        metavar: 'FORMAT',
-        default: 'xml',
-        choices: Object.keys(this.exporters)
-    });
-};
-
-BaseExporters.prototype.handleCommand = function () {
-    var self = this;
-    if (this.parsed_opts.project) {
-        var callback;
-        if (this.parsed_opts.output) {
-            callback = function (err, buffer) {
-                fs.writeFile(self.parsed_opts.output, buffer, function done () {
-                    console.log('Exported project to', self.parsed_opts.output);
-                });
-            };
-        } else {
-            callback = function (err, buffer) {
-                process.stdout.write(buffer);
-            };
-        }
-        var Project = require(path.join(this.root, 'src/back/Project.js')).Project,
-            project = new Project(this, this.parsed_opts.project),
-            options = this.parsed_opts;
-        project.when('loaded', function () {
-            project.export(options, callback);
+class BaseExporters {
+    constructor(config) {
+        config.commands.export = config.opts.command('export').help('Export a project');
+        config.commands.export.option('project', {
+            position: 1,
+            help: 'Project to export.'
         });
-        project.load();
-    }
-};
+        config.commands.export.option('output', {
+            help: 'Filepath to save in',
+            metavar: 'PATH'
+        });
+        config.commands.export.option('width', {
+            help: 'Width of the export',
+            metavar: 'INT',
+            default: 1000
+        });
+        config.commands.export.option('height', {
+            help: 'Height of the export',
+            metavar: 'INT',
+            default: 1000
+        });
+        config.commands.export.option('bounds', {
+            help: 'BBox to use [Default: project extent]',
+            metavar: 'minX,minY,maxX,maxY'
+        });
+        config.commands.export.option('scale', {
+            help: 'Scale the exported image',
+            metavar: 'INT',
+            default: 1
+        });
+        config.on('command:export', this.handleCommand);
+        config.registerExporter('xml', path.join(__dirname, 'XML.js'));
+        config.registerExporter('mml', path.join(__dirname, 'MML.js'));
+        config.registerExporter('yml', path.join(__dirname, 'YAML.js'));
+        config.registerExporter('yaml', path.join(__dirname, 'YAML.js'));
+        config.registerExporter('png', path.join(__dirname, 'PNG.js'));
+        config.registerExporter('png8', path.join(__dirname, 'PNG.js'));
+        config.registerExporter('png24', path.join(__dirname, 'PNG.js'));
+        config.registerExporter('png32', path.join(__dirname, 'PNG.js'));
+        config.registerExporter('png256', path.join(__dirname, 'PNG.js'));
+        config.on('parseopts', this.parseOpts);
+        config.addJS('/src/plugins/base-exporters/front/export.js');
+    };
 
-exports.Plugin = BaseExporters;
+    parseOpts(e) {
+        this.commands.export.option('format', {
+            help: 'Format of the export',
+            metavar: 'FORMAT',
+            default: 'xml',
+            choices: Object.keys(this.exporters)
+        });
+    };
+
+    handleCommand() {
+        var self = this;
+        if (this.parsed_opts.project) {
+            var callback;
+            if (this.parsed_opts.output) {
+                callback = function (err, buffer) {
+                    fs.writeFile(self.parsed_opts.output, buffer, function done () {
+                        console.log('Exported project to', self.parsed_opts.output);
+                    });
+                };
+            } else {
+                callback = function (err, buffer) {
+                    process.stdout.write(buffer);
+                };
+            }
+            var Project = require(path.join(this.root, 'src/back/Project.js')).Project,
+                project = new Project(this, this.parsed_opts.project),
+                options = this.parsed_opts;
+            project.when('loaded', function () {
+                project.export(options, callback);
+            });
+            project.load();
+        }
+    };
+}
+
+exports = module.exports = { Plugin: BaseExporters };

--- a/src/plugins/datasource-loader/index.js
+++ b/src/plugins/datasource-loader/index.js
@@ -2,80 +2,82 @@ var path = require('path'),
     Project = require(path.join(kosmtik.src, 'back/Project.js')).Project,
     Utils = require(path.join(kosmtik.src, 'back/Utils.js'));
 
-var log = function () {
+function log() {
     console.warn.apply(console, Array.prototype.concat.apply(['[datasource loader]'], arguments));
 };
 
-var DataSourceLoader = function (config) {
-    config.beforeState('project:loaded', this.patchMML.bind(this));
-    this._cache = {};
-};
+class DataSourceLoader {
+    constructor(config) {
+        config.beforeState('project:loaded', this.patchMML.bind(this));
+        this._cache = {};
+    };
 
-DataSourceLoader.prototype.patchMML = function (e) {
-    if (!e.project.mml) return e.continue();
-    var processed = 0, self = this,
-        sourceMaxzoom = 100,
-        sources = e.project.mml.source,
-        commit = function () {
-            if (++processed === sources.length){
-                for (var i = 0; i < sources.length; i++) {
-                    sourceMaxzoom = Math.min(sourceMaxzoom, sources[i].maxzoom);
+    patchMML(e) {
+        if (!e.project.mml) return e.continue();
+        var processed = 0, self = this,
+            sourceMaxzoom = 100,
+            sources = e.project.mml.source,
+            commit = function () {
+                if (++processed === sources.length){
+                    for (var i = 0; i < sources.length; i++) {
+                        sourceMaxzoom = Math.min(sourceMaxzoom, sources[i].maxzoom);
+                    }
+                    e.project.mml.sourceMaxzoom = sourceMaxzoom;
+                    e.continue();
                 }
-                e.project.mml.sourceMaxzoom = sourceMaxzoom;
-                e.continue();
-            }
-        },
-        processTileJSON = function (source, json) {
-            self.processTileJSON(source, json);
-            commit();
-        },
-        requestTileJSON = function (source) {
-            e.project.config.helpers.request({uri: source.tilejson}, function (err, resp, body) {
-                if (err) throw err;
-                var json = JSON.parse(body);
-                self._cache[source.tilejson] = json;
-                processTileJSON(source, json);
-            });
-        };
-    if (sources && sources.length) {
-        for (var i = 0; i < sources.length; i++) {
-            if (sources[i].protocol === 'tmsource:') {
-                this.loadLocalSource.bind(this)(sources[i], e.project.config);
+            },
+            processTileJSON = function (source, json) {
+                self.processTileJSON(source, json);
                 commit();
-            } else if (sources[i].tilejson) {
-                if (!this._cache[sources[i].tilejson]) requestTileJSON(sources[i]);
-                else processTileJSON(sources[i], this._cache[sources[i].tilejson]);
+            },
+            requestTileJSON = function (source) {
+                e.project.config.helpers.request({uri: source.tilejson}, function (err, resp, body) {
+                    if (err) throw err;
+                    var json = JSON.parse(body);
+                    self._cache[source.tilejson] = json;
+                    processTileJSON(source, json);
+                });
+            };
+        if (sources && sources.length) {
+            for (var i = 0; i < sources.length; i++) {
+                if (sources[i].protocol === 'tmsource:') {
+                    this.loadLocalSource.bind(this)(sources[i], e.project.config);
+                    commit();
+                } else if (sources[i].tilejson) {
+                    if (!this._cache[sources[i].tilejson]) requestTileJSON(sources[i]);
+                    else processTileJSON(sources[i], this._cache[sources[i].tilejson]);
+                }
             }
         }
-    }
-    e.continue();
-};
-
-DataSourceLoader.prototype.loadLocalSource = function (source, config) {
-    log('Loading source from', source.path);
-    var filepath = path.resolve(source.path),
-        ext = path.extname(filepath);
-    if (ext !== '.yml') filepath = path.join(filepath, 'data.yml');
-    var project = new Project(config, filepath);
-    project.load(false);
-    this.attachSourceUrl(source, project);
-    source.maxzoom = project.mml.maxzoom;
-    config.server.registerProject(project);
-};
-
-DataSourceLoader.prototype.attachSourceUrl = function (source, project) {
-    var params = {
-        host: project.config.parsed_opts.host,
-        port: project.config.parsed_opts.port,
-        path: 'tile/{z}/{x}/{y}.pbf',
-        id: project.id
+        e.continue();
     };
-    source.url = Utils.template('http://{host}:{port}/{id}/{path}', params);
-};
 
-DataSourceLoader.prototype.processTileJSON = function (source, tilejson) {
-    source.url = tilejson.tiles[0];
-    source.maxzoom = tilejson.maxzoom;
-};
+    loadLocalSource(source, config) {
+        log('Loading source from', source.path);
+        var filepath = path.resolve(source.path),
+            ext = path.extname(filepath);
+        if (ext !== '.yml') filepath = path.join(filepath, 'data.yml');
+        var project = new Project(config, filepath);
+        project.load(false);
+        this.attachSourceUrl(source, project);
+        source.maxzoom = project.mml.maxzoom;
+        config.server.registerProject(project);
+    };
 
-exports.Plugin = DataSourceLoader;
+    attachSourceUrl(source, project) {
+        var params = {
+            host: project.config.parsed_opts.host,
+            port: project.config.parsed_opts.port,
+            path: 'tile/{z}/{x}/{y}.pbf',
+            id: project.id
+        };
+        source.url = Utils.template('http://{host}:{port}/{id}/{path}', params);
+    };
+
+    processTileJSON(source, tilejson) {
+        source.url = tilejson.tiles[0];
+        source.maxzoom = tilejson.maxzoom;
+    };
+}
+
+exports = module.exports = { Plugin: DataSourceLoader };

--- a/src/plugins/hash/index.js
+++ b/src/plugins/hash/index.js
@@ -1,27 +1,29 @@
-var Hash = function (config) {
-    config.addJS('/node_modules/leaflet-hash/leaflet-hash.js');
-    config.addJS('/hash.js');
-    config.on('server:init', this.attachRoutes.bind(this));
-};
-
-Hash.prototype.extendMap = function (req, res) {
-
-    var front = function () {
-        L.K.Map.addInitHook(function () {
-            this.hash = new L.Hash(this);
-            if (this.hash.parseHash(location.hash)) {
-                this.hash.update();  // Do not wait for first setTimeout;
-            } else {
-                if (L.K.Config.project) this.setView(L.K.Config.project.center, L.K.Config.project.zoom);
-                else console.error('Missing center and zoom in project config');
-            }
-        });
+class Hash {
+    constructor(config) {
+        config.addJS('/node_modules/leaflet-hash/leaflet-hash.js');
+        config.addJS('/hash.js');
+        config.on('server:init', this.attachRoutes.bind(this));
     };
-    this.pushToFront(res, front);
-};
 
-Hash.prototype.attachRoutes = function (e) {
-    e.server.addRoute('/hash.js', this.extendMap);
-};
+    extendMap(req, res) {
 
-exports.Plugin = Hash;
+        var front = function () {
+            L.K.Map.addInitHook(function () {
+                this.hash = new L.Hash(this);
+                if (this.hash.parseHash(location.hash)) {
+                    this.hash.update();  // Do not wait for first setTimeout;
+                } else {
+                    if (L.K.Config.project) this.setView(L.K.Config.project.center, L.K.Config.project.zoom);
+                    else console.error('Missing center and zoom in project config');
+                }
+            });
+        };
+        this.pushToFront(res, front);
+    };
+
+    attachRoutes(e) {
+        e.server.addRoute('/hash.js', this.extendMap);
+    };
+}
+
+exports = module.exports = { Plugin: Hash };

--- a/src/plugins/local-config/index.js
+++ b/src/plugins/local-config/index.js
@@ -2,57 +2,59 @@ var fs = require('fs'),
     path = require('path'),
     Localizer = require('json-localizer').Localizer;
 
-var LocalConfig = function (config) {
-    config.opts.option('localconfig', {help: 'Path to local config file [Default: {projectpath}/localconfig.json|.js]'});
-    config.beforeState('project:loaded', this.patchMML);
-};
+class LocalConfig {
+    constructor(config) {
+        config.opts.option('localconfig', {help: 'Path to local config file [Default: {projectpath}/localconfig.json|.js]'});
+        config.beforeState('project:loaded', this.patchMML);
+    };
 
-LocalConfig.prototype.patchMML = function (e) {
-    var filepath = this.config.parsed_opts.localconfig,
-        done = function () {
-            e.project.emitAndForward('localconfig:done', e);
-            e.continue();
-        },
-        error = function (err) {
-            err.stack = null; // do not show stack trace
-            console.warn('[Local Config] Unable to load local config from', filepath);
-            console.error(err);
-        };
-    if (!filepath) {
-        filepath = path.join(e.project.root, 'localconfig.json');
+    patchMML(e) {
+        var filepath = this.config.parsed_opts.localconfig,
+            done = function () {
+                e.project.emitAndForward('localconfig:done', e);
+                e.continue();
+            },
+            error = function (err) {
+                err.stack = null; // do not show stack trace
+                console.warn('[Local Config] Unable to load local config from', filepath);
+                console.error(err);
+            };
+        if (!filepath) {
+            filepath = path.join(e.project.root, 'localconfig.json');
+            if (!fs.existsSync(filepath)) {
+                // Do we have a js module instead?
+                filepath = path.join(e.project.root, 'localconfig.js');
+            }
+        }
+        // path.isAbsolute is Node 0.12 only
+        if (path.isAbsolute && !path.isAbsolute(filepath)) filepath = path.join(process.cwd(), filepath);
         if (!fs.existsSync(filepath)) {
-            // Do we have a js module instead?
-            filepath = path.join(e.project.root, 'localconfig.js');
+            error(new Error('File not found: ' + filepath));
+            return done();  // Nothing to do;
         }
-    }
-    // path.isAbsolute is Node 0.12 only
-    if (path.isAbsolute && !path.isAbsolute(filepath)) filepath = path.join(process.cwd(), filepath);
-    if (!fs.existsSync(filepath)) {
-        error(new Error('File not found: ' + filepath));
-        return done();  // Nothing to do;
-    }
-    var l = new Localizer(e.project.mml),
-        ext = path.extname(filepath);
-    if (ext === '.js') {
-        try {
-            new require(filepath).LocalConfig(l, e.project);
-            console.warn('[Local Config] Patched config from', filepath);
-        } catch (err) {
-            error(err);
-        }
-        done();
-    } else {
-        fs.readFile(filepath, 'utf-8', function (err, data) {
-            if (err) error(err);
+        var l = new Localizer(e.project.mml),
+            ext = path.extname(filepath);
+        if (ext === '.js') {
             try {
-                l.fromString(data);
-                console.warn('[Local Config]', 'Patched config from', filepath);
+                new require(filepath).LocalConfig(l, e.project);
+                console.warn('[Local Config] Patched config from', filepath);
             } catch (err) {
                 error(err);
             }
             done();
-        });
-    }
-};
+        } else {
+            fs.readFile(filepath, 'utf-8', function (err, data) {
+                if (err) error(err);
+                try {
+                    l.fromString(data);
+                    console.warn('[Local Config]', 'Patched config from', filepath);
+                } catch (err) {
+                    error(err);
+                }
+                done();
+            });
+        }
+    };
+}
 
-exports.Plugin = LocalConfig;
+exports = module.exports = { Plugin: LocalConfig };


### PR DESCRIPTION
*Preview the diff with whitespace disabled!* [direct link](https://github.com/kosmtik/kosmtik/pull/319/files?diff=split&w=1) 

### This PR

Cleans up the definition of backend classes massively, by using the Javascript `class` syntax. This allows:
- `class A` instead of `.prototype`
- `constructor` and `super` instead of static calls to parent prototypes.
- `A extends B` instead of `util.extends(...)`