### PR TITLE
Travis CI: add Node 10, 12 and 14, remove Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
+  - "14"
+  - "12"
+  - "10"
   - "8"
-  - "6"
 git:
   depth: 10
 env:


### PR DESCRIPTION
See https://nodejs.org/en/about/releases/

Node 6 is dead, node 8 is end of life.

Node 10 is LTS, and node 12 and 14 are current.