### PR TITLE
Fix Data Inspector hang with empty data

### DIFF
--- a/src/back/ProjectServer.js
+++ b/src/back/ProjectServer.js
@@ -152,6 +152,12 @@ class ProjectServer {
             var tile = new tileClass(z, x, y, {metatile: 1, buffer_size: 1});
             return tile.renderToVector(self.project, map, function (err, t) {
                 if (err) return self.raise(err.message, res, release);
+                if (t.getData().length == 0) {
+                    res.writeHead(204, {'Content-Type': 'image/png', 'Content-Length': 0});
+                    res.end();
+                    release();
+                    return;
+                }
                 var xtile = new XRayTile(z, x, y, t.getData(), {layer: query.layer, background: query.background});
                 xtile.render(self.project, map, function (err, im) {
                     if (err) return self.raise(err.message, res, release);


### PR DESCRIPTION
Fix #329
When DataSource returns empty data for an x-ray tile, the XRayTile class doesn't execute the callback, this leads to a full hang.