### PR TITLE
Prewarm the font cache before running any tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": {"kosmtik": "./index.js"},
   "preferGlobal": true,
   "scripts": {
-    "test": "mocha",
+    "test": "mocha --require test/fixtures.js",
     "lint": "eslint src test *.js"
   },
   "keywords": [

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,0 +1,12 @@
+var Config = require('../src/Config.js').Config,
+    Project = require('../src/back/Project.js').Project;
+
+function preWarmTheFontCache() {
+    var config = new Config(__dirname, 'config.yml');
+    new Project(config, 'test/data/minimalist-project.mml');
+}
+
+
+exports.mochaGlobalSetup = function() {
+    preWarmTheFontCache();
+};


### PR DESCRIPTION
Loading the fonts appears to take > 1 second when running inside of GitHub Actions, but subsequent loads are much faster (< 10ms).  I'm not sure why this performance difference exists, but the disk cache is one theory.

Each test has a default timeout of 2 seconds which means that the first test which loads the fonts gets a large performance penalty and can sometimes fail due to timeout.

Increasing the timeouts of the tests may mask some actual performance issues.  So instead I suggest loading the fonts as part of a gobalSetup.

See:
https://mochajs.org/#global-setup-fixtures

Debugging commit which exposed performance information:
863f24cbfcb750ec5b946aaf3e2c757009703599