### PR TITLE
Update mapnik, projection for tiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
+    "@mapnik/mapnik": "^4.6.9",
     "carto": "^1.2.0",
     "js-yaml": "^4.0.0",
     "json-localizer": "0.0.3",
     "leaflet": "^1.3.3",
     "leaflet-formbuilder": "^0.2.0",
     "leaflet-hash": "^0.2.1",
-    "mapnik": "^4.5.9",
     "mapnik-pool": "^0.1.3",
     "nomnom": "^1.8.1",
     "request": "^2.88.0",

--- a/src/Config.js
+++ b/src/Config.js
@@ -4,7 +4,7 @@ var path = require('path'),
     yaml = require('js-yaml'),
     StateBase = require('./back/StateBase.js').StateBase,
     Helpers = require('./back/Helpers.js').Helpers,
-    mapnik = require('mapnik'),
+    mapnik = require('@mapnik/mapnik'),
     PluginsManager = require('./back/PluginsManager.js').PluginsManager,
     packageVersion = require('../package.json').version;
 

--- a/src/back/MetatileBasedTile.js
+++ b/src/back/MetatileBasedTile.js
@@ -1,5 +1,5 @@
 var fs = require('fs'),
-    mapnik = require('mapnik'),
+    mapnik = require('@mapnik/mapnik'),
     Tile = require('./Tile.js').Tile,
     path = require('path');
 

--- a/src/back/Project.js
+++ b/src/back/Project.js
@@ -15,7 +15,7 @@ class Project extends ConfigEmitter {
         try {
             fs.mkdirSync(this.dataDir);
         } catch (err) {}
-        this.mapnik = require('mapnik');
+        this.mapnik = require('@mapnik/mapnik');
         this.mapnikPool = require('mapnik-pool')(this.mapnik);
         this.mapnik.register_default_fonts();
         this.mapnik.register_system_fonts();

--- a/src/back/Tile.js
+++ b/src/back/Tile.js
@@ -1,4 +1,4 @@
-var mapnik = require('mapnik'),
+var mapnik = require('@mapnik/mapnik'),
     zoomXYToLatLng = require('./GeoUtils.js').zoomXYToLatLng;
 
 class Tile {
@@ -9,7 +9,9 @@ class Tile {
         this.z = +z;
         this.x = +x;
         this.y = +y;
-        this.projection = new mapnik.Projection(options.projection || Tile.DEFAULT_OUTPUT_PROJECTION);
+        this.merc = new mapnik.Projection(options.projection || 'epsg:3857' || Tile.DEFAULT_OUTPUT_PROJECTION);
+        var wgs84 = new mapnik.Projection('epsg:4326');
+        this.projection = new mapnik.ProjTransform(wgs84, this.merc);
         this.scale = options.scale || 1;  // When the tile coverage gets bigger (1024px…) or for metatile.
         this.mapScale = options.mapScale;  // Retina.
         this.height = options.height || options.size || DEFAULT_HEIGHT;

--- a/src/back/VectorBasedTile.js
+++ b/src/back/VectorBasedTile.js
@@ -1,4 +1,4 @@
-var mapnik = require('mapnik'),
+var mapnik = require('@mapnik/mapnik'),
     path = require('path'),
     fs = require('fs'),
     Tile = require('./Tile.js').Tile,

--- a/src/back/XRayTile.js
+++ b/src/back/XRayTile.js
@@ -1,4 +1,4 @@
-var mapnik = require('mapnik'),
+var mapnik = require('@mapnik/mapnik'),
     Utils = require('./Utils.js'),
     fs = require('fs'),
     path = require('path'),

--- a/src/plugins/base-exporters/PNG.js
+++ b/src/plugins/base-exporters/PNG.js
@@ -1,4 +1,4 @@
-var mapnik = require('mapnik'),
+var mapnik = require('@mapnik/mapnik'),
     GeoUtils = require('../../back/GeoUtils.js'),
     VectorBasedTile = require('../../back/VectorBasedTile.js').Tile,
     BaseExporter = require('./Base.js').BaseExporter;

--- a/test/tile.js
+++ b/test/tile.js
@@ -3,7 +3,7 @@ var Config = require('../src/Config.js').Config,
     Tile = require('../src/back/Tile.js').Tile,
     fs = require('fs'),
     assert = require('assert'),
-    mapnik = require('mapnik'),
+    mapnik = require('@mapnik/mapnik'),
     process = require('process');
 
 var trunc_6 = function(key, val) {


### PR DESCRIPTION
Small changes to get kosmtik up and running on OSX or Ubuntu

Updates dependency from mapnik to the up-to-date [@mapnik/mapnik](https://www.npmjs.com/package/@mapnik/mapnik), addresses issues with `node-pre-gyp` install in #354 , includes code from [this comment](https://github.com/kosmtik/kosmtik/issues/336#issuecomment-1176573218) to update tile / projection code

Suggestions for documentation: on Ubuntu, if there's an issue `connection to server on socket "/tmp/.s.PGSQL.5432" failed`, in the server's postgresql.conf you need to update `unix_socket_directories` to /tmp/  ( https://dba.stackexchange.com/questions/182189/how-do-i-access-postgres-when-i-get-an-error-about-var-run-postgresql-s-pgsql )