### PR TITLE
Fix raster render ignoring the buffer, and add a buffer-size UI control

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -151,6 +151,10 @@ class Config extends StateBase {
         this.opts.option('metatile', {
             help: 'Override mml metatile setting [Default: mml setting]'
         });
+        this.opts.option('buffer_size', {
+            full: 'buffer-size',
+            help: 'Override mml bufferSize setting, in pixels. Larger values avoid labels/shields being clipped at metatile edges, at the cost of render speed. [Default: mml setting or 256]'
+        });
         this.opts.option('style_id', {
             type: 'string',
             full: 'style-id',

--- a/src/back/MetatileBasedTile.js
+++ b/src/back/MetatileBasedTile.js
@@ -14,12 +14,16 @@ class MetatileBasedTile {
         this.format = options.format || 'png';
         this.size = options.size || 256;
         this.mapScale = options.mapScale || 1;
+        this.buffer_size = options.buffer_size || 0;
         this.options = options;
     }
 
     render(project, map, cb) {
+        // The buffer size is part of the cache key: a metatile rendered with a
+        // different buffer is a different image, so changing the buffer must not
+        // serve a stale cached metatile.
         var self = this, basePath = project.getMetaCacheDir(),
-            baseName = this.z + '.' + this.metaX + '.' + this.metaY + 'x' + this.mapScale,
+            baseName = this.z + '.' + this.metaX + '.' + this.metaY + 'x' + this.mapScale + 'b' + this.buffer_size,
             metaPath = path.join(basePath,  baseName + '.meta'),
             lockPath = path.join(basePath, baseName + '.lock');
 
@@ -69,7 +73,7 @@ class MetatileBasedTile {
 
     renderMetatile(metaPath, project, map, cb) {
         var self = this;
-        var tile = new Tile(self.z, self.metaX, self.metaY, {size: this.metatile * this.size, scale: this.metatile, mapScale: this.mapScale});
+        var tile = new Tile(self.z, self.metaX, self.metaY, {size: this.metatile * this.size, scale: this.metatile, mapScale: this.mapScale, buffer_size: this.buffer_size});
         tile.render(project, map, function (err, im) {
             if (err) return cb(err);
             im.encode(self.format, function (err, buffer) {

--- a/src/back/Project.js
+++ b/src/back/Project.js
@@ -61,7 +61,7 @@ class Project extends ConfigEmitter {
         options = options || {};
         this.render();
         this.config.log('Loading map…');
-        if (!options.bufferSize) options.bufferSize = this.mml.bufferSize || 256;
+        if (!options.bufferSize) options.bufferSize = this.bufferSize();
         if(!options.size) options.size = this.metatileSize() * (options.scale || 1);
         this.mapPool = this.mapnikPool.fromString(this.xml, options, {base: this.root});
         this.config.log('Map ready');
@@ -85,6 +85,7 @@ class Project extends ConfigEmitter {
             metatile: this.metatile(),
             name: this.mml.name || '',
             tileSize: this.tileSize(),
+            bufferSize: this.bufferSize(),
             loadTime: this.loadTime,
             layers: this.mml.Layer || []
         };
@@ -94,6 +95,10 @@ class Project extends ConfigEmitter {
 
     tileSize() {
         return 256;
+    };
+
+    bufferSize() {
+        return this.mml.bufferSize || 256;
     };
 
     metatileSize() {

--- a/src/back/Project.js
+++ b/src/back/Project.js
@@ -85,7 +85,6 @@ class Project extends ConfigEmitter {
             metatile: this.metatile(),
             name: this.mml.name || '',
             tileSize: this.tileSize(),
-            bufferSize: this.bufferSize(),
             loadTime: this.loadTime,
             layers: this.mml.Layer || []
         };
@@ -98,6 +97,14 @@ class Project extends ConfigEmitter {
     };
 
     bufferSize() {
+        // --buffer-size on the CLI overrides the mml setting. parseInt so a
+        // string arg ("0") works, and so an explicit 0 (no buffer) is honoured
+        // rather than falling through as falsy.
+        var cli = this.config.parsed_opts.buffer_size;
+        if (cli !== undefined && cli !== null && cli !== '') {
+            var n = parseInt(cli, 10);
+            if (!isNaN(n)) return n;
+        }
         return this.mml.bufferSize || 256;
     };
 

--- a/src/back/ProjectServer.js
+++ b/src/back/ProjectServer.js
@@ -69,26 +69,21 @@ class ProjectServer {
         }
     };
 
-    tile(z, x, y, res, query) {
-        query = query || {};
+    tile(z, x, y, res) {
         var self = this,
             yels = y.split('@'),
             y = yels[0],
             scale = yels[1] ? parseInt(yels[1], 10) : 1,
             mapScale = scale * (this.project.mml.scale || 1),
             size = this.project.tileSize() * scale,  // retina?
-            // Let the UI override the Mapnik buffer size per request; fall back
-            // to the project default.
-            buffer = (query.buffer !== undefined && query.buffer !== '') ? parseInt(query.buffer, 10) : this.project.bufferSize(),
+            // The map pool is already created with this buffer; pass it to the
+            // tile too so the raster render uses it (Mapnik ignores the Map's
+            // bufferSize property when rendering to an image).
+            buffer = this.project.bufferSize(),
             mapPool = scale === 2 ? this.retinaPool : this.mapPool;
-        if (isNaN(buffer)) buffer = self.project.bufferSize();
         mapPool.acquire(function (err, map) {
             var release = function () {mapPool.release(map);};
             if (err) return self.raise(err.message, res);
-            // Apply on the pooled map (datasource query buffer) and pass it
-            // through to the tile (raster render buffer). Maps are pooled and
-            // reused, so set this explicitly on every request.
-            map.bufferSize = buffer;
             var tileClass = self.project.mml.source ? VectorBasedTile : self.project.metatile() === 1 ? Tile : MetatileBasedTile;
             var tile = new tileClass(z, x, y, {size: size, metatile: self.project.metatile(), mapScale: mapScale, buffer_size: buffer});
             return tile.render(self.project, map, function (err, im) {

--- a/src/back/ProjectServer.js
+++ b/src/back/ProjectServer.js
@@ -69,19 +69,28 @@ class ProjectServer {
         }
     };
 
-    tile(z, x, y, res) {
+    tile(z, x, y, res, query) {
+        query = query || {};
         var self = this,
             yels = y.split('@'),
             y = yels[0],
             scale = yels[1] ? parseInt(yels[1], 10) : 1,
             mapScale = scale * (this.project.mml.scale || 1),
             size = this.project.tileSize() * scale,  // retina?
+            // Let the UI override the Mapnik buffer size per request; fall back
+            // to the project default.
+            buffer = (query.buffer !== undefined && query.buffer !== '') ? parseInt(query.buffer, 10) : this.project.bufferSize(),
             mapPool = scale === 2 ? this.retinaPool : this.mapPool;
+        if (isNaN(buffer)) buffer = self.project.bufferSize();
         mapPool.acquire(function (err, map) {
             var release = function () {mapPool.release(map);};
             if (err) return self.raise(err.message, res);
+            // Apply on the pooled map (datasource query buffer) and pass it
+            // through to the tile (raster render buffer). Maps are pooled and
+            // reused, so set this explicitly on every request.
+            map.bufferSize = buffer;
             var tileClass = self.project.mml.source ? VectorBasedTile : self.project.metatile() === 1 ? Tile : MetatileBasedTile;
-            var tile = new tileClass(z, x, y, {size: size, metatile: self.project.metatile(), mapScale: mapScale});
+            var tile = new tileClass(z, x, y, {size: size, metatile: self.project.metatile(), mapScale: mapScale, buffer_size: buffer});
             return tile.render(self.project, map, function (err, im) {
                 if (err) return self.raise(err.message, res, release);
                 im.encode('png', (function (err, buffer) {

--- a/src/back/Tile.js
+++ b/src/back/Tile.js
@@ -32,7 +32,11 @@ class Tile {
         this.setupBounds();
         map.zoomToBox(this.projection.forward([this.minX, this.minY, this.maxX, this.maxY]));
         var im = new mapnik.Image(this.height, this.width);
-        map.render(im, {scale: this.mapScale || 1, variables: {zoom: this.z}}, cb);
+        // buffer_size must be passed in the render options: Mapnik does not use
+        // the Map's bufferSize property for image rendering, so without this the
+        // raster render buffer is 0 and symbols (e.g. shields) are clipped at
+        // metatile edges, even when map.bufferSize is set.
+        map.render(im, {scale: this.mapScale || 1, buffer_size: this.buffer_size, variables: {zoom: this.z}}, cb);
     };
 
     renderToVector(project, map, cb) {

--- a/src/front/Map.js
+++ b/src/front/Map.js
@@ -1,24 +1,3 @@
-// Numeric input for the Mapnik buffer size.
-// The idea is to not re-render on every keystroke, since re-rendering each intermediate value (2, then 25, then 256…) is very slow.
-L.Kosmtik.BufferInput = L.FormBuilder.BlurIntInput.extend({
-
-    value: function () {
-        var v = parseInt(this.input.value, 10);
-        if (isNaN(v) || v < 0) v = 0;
-        if (String(v) !== this.input.value) this.input.value = v;  // normalise the displayed text (e.g. '' -> '0')
-        return v;
-    },
-
-    sync: function () {
-        var v = this.value();
-        if (this.initial !== v) {
-            L.FormBuilder.Input.prototype.sync.call(this);  // presync -> set -> postsync (commit + redraw)
-            this.initial = v;  // don't re-commit the same value on a subsequent blur
-        }
-    }
-
-});
-
 L.Kosmtik.Map = L.Map.extend({
 
     options: {
@@ -26,14 +5,11 @@ L.Kosmtik.Map = L.Map.extend({
     },
 
     initialize: function (options) {
-        // Buffer size defaults to the project's configured value.
-        if (L.K.Config.buffer === undefined) L.K.Config.buffer = L.K.Config.project.bufferSize || 256;
         this.sidebar = new L.Kosmtik.Sidebar().addTo(this);
         this.toolbar = new L.Kosmtik.Toolbar().addTo(this);
         this.commands = new L.Kosmtik.Command(this);
         this.settingsForm = new L.K.SettingsForm(this);
         this.settingsForm.addElement(['autoReload', {handler: L.K.Switch, label: 'Autoreload', helpText: 'Reload map as soon as a project file is changed on the server.'}]);
-        this.settingsForm.addElement(['buffer', {handler: L.K.BufferInput, label: 'Buffer size (px)', helpText: 'Mapnik render buffer in pixels. Larger values avoid labels/shields being clipped at tile edges, at the cost of render speed. Applied on blur or Enter.'}]);
         this.settingsForm.addElement(['backendPolling', {handler: L.K.Switch, label: '(Advanced) Poll backend for project updates'}]);
         this.createPollIndicator();
         this.createReloadButton();
@@ -46,11 +22,10 @@ L.Kosmtik.Map = L.Map.extend({
         var tilelayerOptions = {
             version: L.K.Config.project.loadTime,
             tileSize: L.K.Config.project.tileSize,
-            buffer: L.K.Config.buffer,
             minZoom: this.options.minZoom,
             maxZoom: this.options.maxZoom
         };
-        this.tilelayer = new L.TileLayer('./tile/{z}/{x}/{y}{r}.png?t={version}&buffer={buffer}', tilelayerOptions).addTo(this);
+        this.tilelayer = new L.TileLayer('./tile/{z}/{x}/{y}{r}.png?t={version}', tilelayerOptions).addTo(this);
         this.tilelayer.on('loading', function () {
             this.setState('loading');
         }, this);
@@ -64,10 +39,6 @@ L.Kosmtik.Map = L.Map.extend({
         });
         this.on('settings:synced', function (e) {
             if (e.helper.field === 'backendPolling') this.togglePoll();
-            if (e.helper.field === 'buffer') {
-                this.tilelayer.options.buffer = L.K.Config.buffer;
-                this.tilelayer.redraw();
-            }
         });
         this.help = new L.Kosmtik.Help(this);
         if(L.K.Config.project.name.length) document.title = L.K.Config.project.name + ' — Kosmtik';

--- a/src/front/Map.js
+++ b/src/front/Map.js
@@ -1,3 +1,24 @@
+// Numeric input for the Mapnik buffer size.
+// The idea is to not re-render on every keystroke, since re-rendering each intermediate value (2, then 25, then 256…) is very slow.
+L.Kosmtik.BufferInput = L.FormBuilder.BlurIntInput.extend({
+
+    value: function () {
+        var v = parseInt(this.input.value, 10);
+        if (isNaN(v) || v < 0) v = 0;
+        if (String(v) !== this.input.value) this.input.value = v;  // normalise the displayed text (e.g. '' -> '0')
+        return v;
+    },
+
+    sync: function () {
+        var v = this.value();
+        if (this.initial !== v) {
+            L.FormBuilder.Input.prototype.sync.call(this);  // presync -> set -> postsync (commit + redraw)
+            this.initial = v;  // don't re-commit the same value on a subsequent blur
+        }
+    }
+
+});
+
 L.Kosmtik.Map = L.Map.extend({
 
     options: {
@@ -5,11 +26,14 @@ L.Kosmtik.Map = L.Map.extend({
     },
 
     initialize: function (options) {
+        // Buffer size defaults to the project's configured value.
+        if (L.K.Config.buffer === undefined) L.K.Config.buffer = L.K.Config.project.bufferSize || 256;
         this.sidebar = new L.Kosmtik.Sidebar().addTo(this);
         this.toolbar = new L.Kosmtik.Toolbar().addTo(this);
         this.commands = new L.Kosmtik.Command(this);
         this.settingsForm = new L.K.SettingsForm(this);
         this.settingsForm.addElement(['autoReload', {handler: L.K.Switch, label: 'Autoreload', helpText: 'Reload map as soon as a project file is changed on the server.'}]);
+        this.settingsForm.addElement(['buffer', {handler: L.K.BufferInput, label: 'Buffer size (px)', helpText: 'Mapnik render buffer in pixels. Larger values avoid labels/shields being clipped at tile edges, at the cost of render speed. Applied on blur or Enter.'}]);
         this.settingsForm.addElement(['backendPolling', {handler: L.K.Switch, label: '(Advanced) Poll backend for project updates'}]);
         this.createPollIndicator();
         this.createReloadButton();
@@ -22,10 +46,11 @@ L.Kosmtik.Map = L.Map.extend({
         var tilelayerOptions = {
             version: L.K.Config.project.loadTime,
             tileSize: L.K.Config.project.tileSize,
+            buffer: L.K.Config.buffer,
             minZoom: this.options.minZoom,
             maxZoom: this.options.maxZoom
         };
-        this.tilelayer = new L.TileLayer('./tile/{z}/{x}/{y}{r}.png?t={version}', tilelayerOptions).addTo(this);
+        this.tilelayer = new L.TileLayer('./tile/{z}/{x}/{y}{r}.png?t={version}&buffer={buffer}', tilelayerOptions).addTo(this);
         this.tilelayer.on('loading', function () {
             this.setState('loading');
         }, this);
@@ -39,6 +64,10 @@ L.Kosmtik.Map = L.Map.extend({
         });
         this.on('settings:synced', function (e) {
             if (e.helper.field === 'backendPolling') this.togglePoll();
+            if (e.helper.field === 'buffer') {
+                this.tilelayer.options.buffer = L.K.Config.buffer;
+                this.tilelayer.redraw();
+            }
         });
         this.help = new L.Kosmtik.Help(this);
         if(L.K.Config.project.name.length) document.title = L.K.Config.project.name + ' — Kosmtik';


### PR DESCRIPTION
When discussing an issue on OSM-Carto, see [here](https://github.com/openstreetmap-carto/openstreetmap-carto/pull/5229#issuecomment-4514002554) and the following two comments, we realized that the buffer size was behaving strangely in kosmtik.

It turns out that kosmtik is correctly expanding the query !bbox! by the buffer, which is good, but not expanding the mapnik raster. This results in some elements, in particular highway shields, being torn at metatile boundaries. This PR fixes that bug, and allows the buffer size to be configurable.

Examples:

|Location|Before this PR|After, default (256px)|After, buffer set to 0px|
|---|---|---|---|
|`#11/34.1010/-118.4745`|<img width="85" height="92" alt="Screen Shot 2026-05-30 at 2 29 12 PM" src="https://github.com/user-attachments/assets/ca9c657a-99b0-4f15-9336-efaa1b1b70a7" />|<img width="103" height="96" alt="Screen Shot 2026-05-30 at 2 29 32 PM" src="https://github.com/user-attachments/assets/edec131a-790e-41ee-bb3c-be39ec038944" />|<img width="100" height="92" alt="Screen Shot 2026-05-30 at 2 31 06 PM" src="https://github.com/user-attachments/assets/d674b598-751e-4415-bf8c-ea9db9256355" />|
|`#13/40.7137/-73.9849`|<img width="280" alt="Screen Shot 2026-05-30 at 2 38 32 PM" src="https://github.com/user-attachments/assets/48d347f3-9354-4339-aa1e-700a1031ecf3" />|<img width="280" alt="Screen Shot 2026-05-30 at 2 38 22 PM" src="https://github.com/user-attachments/assets/77e4ada1-d9fa-41a9-a131-1e706a75787d" />|<img width="280" alt="Screen Shot 2026-05-30 at 2 37 33 PM" src="https://github.com/user-attachments/assets/7c07dc4b-390b-4318-b46b-07f46071d02c" />|

As you can see, after this PR, if you set the buffer to 0px, it's actually worse than before (e.g. "New York" is ripped) because not just the mapnik raster is unbuffered, but the SQL !bbox! is now unbuffered too. As expected.



Here's the new setting:
<img width="300" alt="Screen Shot 2026-05-30 at 2 31 48 PM" src="https://github.com/user-attachments/assets/b131417b-97be-4e8e-8819-43d873769b97" />


